### PR TITLE
Add timeframe filtering to forecast charts

### DIFF
--- a/__tests__/ForecastChartView.test.js
+++ b/__tests__/ForecastChartView.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+function filterMetrics(metrics, timeframe) {
+  if (timeframe === 'all') return metrics;
+  const days = timeframe === '7d' ? 7 : timeframe === '30d' ? 30 : 90;
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+  return metrics.filter(m => m.date >= cutoff);
+}
+
+test('filters metrics within timeframe', () => {
+  const now = Date.now();
+  const metrics = [
+    {date: now - 10 * 24 * 60 * 60 * 1000},
+    {date: now - 5 * 24 * 60 * 60 * 1000},
+  ];
+  const result = filterMetrics(metrics, '7d');
+  assert.strictEqual(result.length, 1);
+});

--- a/components/forecast/ForecastChartView.tsx
+++ b/components/forecast/ForecastChartView.tsx
@@ -3,12 +3,23 @@
 import { ForecastChartViewProps } from './types';
 import NetWorthChart from '../net-worth-chart';
 
-export function ForecastChartView({ 
-  realMetrics, 
-  projectedMetrics, 
-  dataView, 
-  setDataView 
+export function ForecastChartView({
+  realMetrics,
+  projectedMetrics,
+  dataView,
+  setDataView,
+  timeframe,
+  setTimeframe
 }: ForecastChartViewProps) {
+  const filterByTimeframe = (metrics: any[]) => {
+    if (timeframe === 'all') return metrics;
+    const days = timeframe === '7d' ? 7 : timeframe === '30d' ? 30 : 90;
+    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+    return metrics.filter(m => m.date >= cutoff);
+  };
+
+  const filteredReal = filterByTimeframe(realMetrics);
+  const filteredProjected = filterByTimeframe(projectedMetrics);
   return (
     <>
       <div className="flex justify-end mb-2">
@@ -16,8 +27,8 @@ export function ForecastChartView({
           <button
             onClick={() => setDataView('all')}
             className={`px-4 py-2 text-sm transition-colors cursor-pointer ${
-              dataView === 'all' 
-                ? 'bg-blue-500 text-white' 
+              dataView === 'all'
+                ? 'bg-blue-500 text-white'
                 : 'hover:bg-gray-800 dark:hover:bg-gray-700'
             }`}
           >
@@ -44,6 +55,16 @@ export function ForecastChartView({
             Projections
           </button>
         </div>
+        <select
+          className="ml-2 px-3 py-2 text-sm rounded-lg border border-gray-700 bg-gray-900 text-white"
+          value={timeframe}
+          onChange={(e) => setTimeframe(e.target.value as '7d' | '30d' | '90d' | 'all')}
+        >
+          <option value="7d">7d</option>
+          <option value="30d">30d</option>
+          <option value="90d">90d</option>
+          <option value="all">All</option>
+        </select>
       </div>
       
       {/* Display charts based on selected view */}
@@ -52,21 +73,21 @@ export function ForecastChartView({
           <div className="w-full">
             <h3 className="text-lg font-medium mb-2">Historical Data</h3>
             <div className="w-full h-[400px]">
-              <NetWorthChart metrics={realMetrics} showUncertainty={false} />
+              <NetWorthChart metrics={filteredReal} showUncertainty={false} />
             </div>
           </div>
           
           <div className="w-full">
             <h3 className="text-lg font-medium mb-2">Projected Data</h3>
             <div className="w-full h-[400px]">
-              <NetWorthChart metrics={projectedMetrics} showUncertainty={true} />
+              <NetWorthChart metrics={filteredProjected} showUncertainty={true} />
             </div>
           </div>
         </div>
       ) : (
         <div className="w-full h-[400px]">
           <NetWorthChart 
-            metrics={dataView === 'real' ? realMetrics : projectedMetrics} 
+            metrics={dataView === 'real' ? filteredReal : filteredProjected}
             showUncertainty={dataView === 'projected'}
           />
         </div>

--- a/components/forecast/ForecastClient.tsx
+++ b/components/forecast/ForecastClient.tsx
@@ -46,6 +46,9 @@ export function ForecastClient({
   const [dataView, setDataView] = useState<'all' | 'real' | 'projected'>(
     (defaultPrefs.forecastDataView as 'all' | 'real' | 'projected') || 'all'
   );
+  const [timeframe, setTimeframe] = useState<'7d' | '30d' | '90d' | 'all'>(
+    (defaultPrefs.forecastTimeframe as '7d' | '30d' | '90d' | 'all') || 'all'
+  );
   
   const [simulationData, setSimulationData] = useState<SimulationData | null>(null);
   
@@ -76,6 +79,11 @@ export function ForecastClient({
   const updateDataView = (value: 'all' | 'real' | 'projected') => {
     setDataView(value);
     setPreference({ key: "forecastDataView", value });
+  };
+
+  const updateTimeframe = (value: '7d' | '30d' | '90d' | 'all') => {
+    setTimeframe(value);
+    setPreference({ key: 'forecastTimeframe', value });
   };
   
   // Load simulation data from local storage
@@ -366,6 +374,8 @@ export function ForecastClient({
         projectedMetrics={projectedMetrics}
         dataView={dataView}
         setDataView={updateDataView}
+        timeframe={timeframe}
+        setTimeframe={updateTimeframe}
       />
       
       <ForecastControls

--- a/components/forecast/types.ts
+++ b/components/forecast/types.ts
@@ -30,6 +30,8 @@ export interface ForecastChartViewProps {
   projectedMetrics: DailyMetric[];
   dataView: 'all' | 'real' | 'projected';
   setDataView: (view: 'all' | 'real' | 'projected') => void;
+  timeframe: '7d' | '30d' | '90d' | 'all';
+  setTimeframe: (tf: '7d' | '30d' | '90d' | 'all') => void;
 }
 
 export interface ForecastEmptyStateProps {
@@ -44,6 +46,7 @@ export interface UserPreferences {
   monthlyIncome?: number;
   monthlyCost?: number;
   forecastDataView?: "all" | "real" | "projected";
+  forecastTimeframe?: '7d' | '30d' | '90d' | 'all';
   theme?: "light" | "dark" | "system";
   dashboardLayout?: string[];
   customSettings?: any;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -133,7 +133,8 @@ export default defineSchema({
       monthlyIncome: v.optional(v.number()),
       monthlyCost: v.optional(v.number()),
       forecastDataView: v.optional(v.union(v.literal("all"), v.literal("real"), v.literal("projected"))),
-      
+      forecastTimeframe: v.optional(v.union(v.literal('7d'), v.literal('30d'), v.literal('90d'), v.literal('all'))),
+
       // Other preferences can be added here as needed
       theme: v.optional(v.union(v.literal("light"), v.literal("dark"), v.literal("system"))),
       dashboardLayout: v.optional(v.array(v.string())),

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -8,6 +8,7 @@ const DEFAULT_PREFERENCES = {
   monthlyIncome: 18000,
   monthlyCost: 10000,
   forecastDataView: "all" as "all" | "real" | "projected",
+  forecastTimeframe: 'all' as '7d' | '30d' | '90d' | 'all',
   theme: "dark" as "light" | "dark" | "system",
   dashboardLayout: [] as string[],
   customSettings: {}
@@ -116,6 +117,7 @@ export const updatePreferences = mutation({
       monthlyIncome: v.optional(v.number()),
       monthlyCost: v.optional(v.number()),
       forecastDataView: v.optional(v.union(v.literal("all"), v.literal("real"), v.literal("projected"))),
+      forecastTimeframe: v.optional(v.union(v.literal('7d'), v.literal('30d'), v.literal('90d'), v.literal('all'))),
       theme: v.optional(v.union(v.literal("light"), v.literal("dark"), v.literal("system"))),
       dashboardLayout: v.optional(v.array(v.string())),
       customSettings: v.optional(v.any())

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.12.4",


### PR DESCRIPTION
## Summary
- support selecting timeframe in `ForecastChartView`
- persist timeframe in user preferences
- expose timeframe and setter through `ForecastClient`
- extend schema and convex logic for new preference
- add simple node-based test for filtering
- add `test` script to package.json

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*