### PR TITLE
Add bun test for formatNumber

### DIFF
--- a/__tests__/ForecastChartView.test.js
+++ b/__tests__/ForecastChartView.test.js
@@ -1,5 +1,4 @@
-import assert from 'node:assert';
-import test from 'node:test';
+import { test, expect } from 'bun:test';
 
 function filterMetrics(metrics, timeframe) {
   if (timeframe === 'all') return metrics;
@@ -11,9 +10,9 @@ function filterMetrics(metrics, timeframe) {
 test('filters metrics within timeframe', () => {
   const now = Date.now();
   const metrics = [
-    {date: now - 10 * 24 * 60 * 60 * 1000},
-    {date: now - 5 * 24 * 60 * 60 * 1000},
+    { date: now - 10 * 24 * 60 * 60 * 1000 },
+    { date: now - 5 * 24 * 60 * 60 * 1000 },
   ];
   const result = filterMetrics(metrics, '7d');
-  assert.strictEqual(result.length, 1);
+  expect(result.length).toBe(1);
 });

--- a/__tests__/formatNumber.test.ts
+++ b/__tests__/formatNumber.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from 'bun:test';
+import { formatNumber } from '../lib/formatters';
+
+test('formats small numbers using scientific notation', () => {
+  expect(formatNumber(0.005)).toBe('5.00e-3');
+});
+
+test('formats thousands with K suffix', () => {
+  expect(formatNumber(1234)).toBe('1.23K');
+});
+
+test('formats millions with M suffix', () => {
+  expect(formatNumber(2500000)).toBe('2.50M');
+});
+
+test('uses default formatting for ordinary numbers', () => {
+  expect(formatNumber(42)).toBe('42');
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node --test"
+    "test": "bun test"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.12.4",


### PR DESCRIPTION
## Summary
- switch to `bun test` for running tests
- migrate existing test to use bun's test runner
- add tests for `formatNumber` covering scientific notation, thousands, millions and default formatting

## Testing
- `bun test`
