### PR TITLE
Show totals on asset, debt and wallet cards

### DIFF
--- a/components/cards/assets-card.tsx
+++ b/components/cards/assets-card.tsx
@@ -26,6 +26,11 @@ export default function AssetsCard({ assets: initialAssets }: AssetsCardProps) {
     return [...assets].sort((a, b) => b.value - a.value);
   }, [assets]);
 
+  const totalAssets = useMemo(() => {
+    if (!assets) return 0;
+    return assets.reduce((sum, asset) => sum + asset.value, 0);
+  }, [assets]);
+
   // Helper function to get icon based on asset type
   const getAssetTypeIcon = (type: string) => {
     switch (type) {
@@ -46,7 +51,12 @@ export default function AssetsCard({ assets: initialAssets }: AssetsCardProps) {
 
   return (
     <div className="relative bg-white/5 rounded-lg p-6 backdrop-blur-sm">
-      <h2 className="text-xl font-semibold mb-4">Assets</h2>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-semibold">Assets</h2>
+        <span className="text-green-500 font-mono">
+          {`Total: $${formatNumber(totalAssets)}`}
+        </span>
+      </div>
       <button
         onClick={() => setShowAddForm(true)}
         className="absolute top-2 right-2 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800"

--- a/components/cards/debts-card.tsx
+++ b/components/cards/debts-card.tsx
@@ -26,6 +26,11 @@ export default function DebtsCard({ debts: initialDebts }: DebtsCardProps) {
     return [...debts].sort((a, b) => b.value - a.value);
   }, [debts]);
 
+  const totalDebts = useMemo(() => {
+    if (!debts) return 0;
+    return debts.reduce((sum, debt) => sum + debt.value, 0);
+  }, [debts]);
+
   // Helper function to get icon based on debt type
   const getDebtTypeIcon = (type: string) => {
     switch (type) {
@@ -44,7 +49,12 @@ export default function DebtsCard({ debts: initialDebts }: DebtsCardProps) {
 
   return (
     <div className="relative bg-white/5 rounded-lg p-6 backdrop-blur-sm">
-      <h2 className="text-xl font-semibold mb-4">Debts</h2>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-semibold">Debts</h2>
+        <span className="text-red-500 font-mono">
+          {`Total: $${formatNumber(totalDebts)}`}
+        </span>
+      </div>
       <button
         onClick={() => setShowAddForm(true)}
         className="absolute top-2 right-2 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800"

--- a/components/cards/wallets-card.tsx
+++ b/components/cards/wallets-card.tsx
@@ -57,6 +57,11 @@ export default function CryptoWalletsCard({ wallets: initialWallets }: CryptoWal
     });
   }, [wallets]);
 
+  const totalWallets = useMemo(() => {
+    if (!wallets) return 0;
+    return wallets.reduce((sum, wallet) => sum + (wallet.value || 0), 0);
+  }, [wallets]);
+
   const handleUpdateWallets = async () => {
     try {
       setIsUpdating(true);
@@ -70,7 +75,12 @@ export default function CryptoWalletsCard({ wallets: initialWallets }: CryptoWal
 
   return (
     <div className="relative bg-white/5 rounded-lg p-6 backdrop-blur-sm">
-      <h2 className="text-xl font-semibold mb-4">Wallets</h2>
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-semibold">Wallets</h2>
+        <span className="text-green-500 font-mono">
+          {`Total: $${formatNumber(totalWallets)}`}
+        </span>
+      </div>
       <AddButton onClick={() => setShowAddForm(true)} />
       <UpdateButton onClick={handleUpdateWallets} isUpdating={isUpdating} />
       


### PR DESCRIPTION
## Summary
- compute totals for each card
- show totals next to card headers

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*