### PR TITLE
Show recurring totals on dashboard

### DIFF
--- a/components/forecast/ForecastClient.tsx
+++ b/components/forecast/ForecastClient.tsx
@@ -5,7 +5,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { DailyMetric, UserPreferences, UserPreferencesData, RecurringTotals } from './types';
 import { ForecastEmptyState } from './ForecastEmptyState';
-import { ForecastControls } from './ForecastControls';
+import RecurringTotalsCard from '@/components/recurring/RecurringTotalsCard';
 import { ForecastSummary } from './ForecastSummary';
 import { ForecastChartView } from './ForecastChartView';
 
@@ -404,12 +404,7 @@ export function ForecastClient({
         setTimeframe={updateTimeframe}
       />
       
-      <ForecastControls
-        monthlyCost={monthlyCost}
-        setMonthlyCost={updateMonthlyCost}
-        monthlyIncome={monthlyIncome}
-        setMonthlyIncome={updateMonthlyIncome}
-      />
+      <RecurringTotalsCard initialTotals={recurringTotals} />
     </div>
   );
-} 
+}

--- a/components/forecast/ForecastEmptyState.tsx
+++ b/components/forecast/ForecastEmptyState.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ForecastEmptyStateProps } from './types';
-import { Slider } from './Slider';
+import RecurringTotalsCard from '@/components/recurring/RecurringTotalsCard';
 
 export function ForecastEmptyState({ 
   monthlyCost, 
@@ -20,31 +20,8 @@ export function ForecastEmptyState({
           Add some assets, debts, or wallets to start tracking your net worth and see projections.
         </p>
       </div>
-      
-      <div className="flex flex-col gap-4 p-4 border rounded-lg">
-        <h3 className="text-lg font-medium mb-2">Forecast Settings</h3>
-        <p className="text-sm text-gray-500 mb-4">
-          These settings will be used to generate projections once you have financial data.
-        </p>
-        
-        <Slider
-          value={monthlyCost}
-          onChange={setMonthlyCost}
-          min={0}
-          max={50000}
-          step={100}
-          label="Monthly Costs"
-        />
 
-        <Slider
-          value={monthlyIncome}
-          onChange={setMonthlyIncome}
-          min={0}
-          max={50000}
-          step={100}
-          label="Monthly Income"
-        />
-      </div>
+      <RecurringTotalsCard initialTotals={{ monthlyIncome, monthlyCost }} />
     </div>
   );
-} 
+}

--- a/components/recurring/RecurringPageClient.tsx
+++ b/components/recurring/RecurringPageClient.tsx
@@ -23,7 +23,7 @@ export default function RecurringPageClient({ initialData }: RecurringPageClient
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Recurring Transactions</h1>
         <button
           onClick={() => setShowForm(true)}
@@ -32,6 +32,7 @@ export default function RecurringPageClient({ initialData }: RecurringPageClient
           Add
         </button>
       </div>
+      <div className="bg-white/5 rounded-lg p-6 backdrop-blur-sm">
       <table className="min-w-full text-sm">
         <thead>
           <tr>
@@ -65,6 +66,7 @@ export default function RecurringPageClient({ initialData }: RecurringPageClient
           ))}
         </tbody>
       </table>
+      </div>
       {showForm && (
         <Modal onClose={() => setShowForm(false)}>
           <TransactionForm onClose={() => setShowForm(false)} />

--- a/components/recurring/RecurringTotalsCard.tsx
+++ b/components/recurring/RecurringTotalsCard.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { RecurringTotals } from '@/components/forecast/types';
+import Link from 'next/link';
+import { formatNumber } from '@/lib/formatters';
+
+interface RecurringTotalsCardProps {
+  initialTotals: RecurringTotals;
+}
+
+export default function RecurringTotalsCard({ initialTotals }: RecurringTotalsCardProps) {
+  const totals = useQuery(api.recurring.getMonthlyTotals) ?? initialTotals;
+
+  return (
+    <div className="flex flex-col gap-2 bg-gray-800 p-4 rounded-lg">
+      <h3 className="text-lg font-medium mb-2">Recurring Totals</h3>
+      <div className="flex justify-between">
+        <span className="text-sm text-gray-400">Monthly Income</span>
+        <span className="text-green-500 font-mono">${formatNumber(totals.monthlyIncome)}</span>
+      </div>
+      <div className="flex justify-between">
+        <span className="text-sm text-gray-400">Monthly Costs</span>
+        <span className="text-red-500 font-mono">${formatNumber(totals.monthlyCost)}</span>
+      </div>
+      <Link href="/recurring" className="text-blue-400 hover:underline text-sm mt-2">
+        Manage Recurring
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- style recurring transactions page
- add a card to display totals from recurring items
- link the card to the recurring page
- remove sliders from forecast controls in favour of recurring totals

## Testing
- `bun test`