### PR TITLE
Enhance recurring transactions and forecast defaults

### DIFF
--- a/components/forecast/ForecastClient.tsx
+++ b/components/forecast/ForecastClient.tsx
@@ -42,8 +42,16 @@ export function ForecastClient({
   // Initialize state from server-side preferences, falling back to defaults
   const defaultPrefs = initialPreferences?.preferences || {};
   
-  const [monthlyCost, setMonthlyCost] = useState(defaultPrefs.monthlyCost || 10000);
-  const [monthlyIncome, setMonthlyIncome] = useState(defaultPrefs.monthlyIncome || 18000);
+  const [monthlyCost, setMonthlyCost] = useState(
+    defaultPrefs.monthlyCost !== undefined
+      ? defaultPrefs.monthlyCost
+      : initialRecurring?.monthlyCost || 0
+  );
+  const [monthlyIncome, setMonthlyIncome] = useState(
+    defaultPrefs.monthlyIncome !== undefined
+      ? defaultPrefs.monthlyIncome
+      : initialRecurring?.monthlyIncome || 0
+  );
   const [useSimulationData, setUseSimulationData] = useState(defaultPrefs.useSimulationData || false);
   const [dataView, setDataView] = useState<'all' | 'real' | 'projected'>(
     (defaultPrefs.forecastDataView as 'all' | 'real' | 'projected') || 'all'

--- a/components/forecast/ForecastControls.tsx
+++ b/components/forecast/ForecastControls.tsx
@@ -28,6 +28,9 @@ export function ForecastControls({
         step={100}
         label="Monthly Income"
       />
+      <a href="/recurring" className="text-sm text-blue-500 hover:underline self-end">
+        Manage Recurring Transactions
+      </a>
     </div>
   );
-} 
+}

--- a/components/forecast/ForecastEmptyState.tsx
+++ b/components/forecast/ForecastEmptyState.tsx
@@ -44,6 +44,9 @@ export function ForecastEmptyState({
           step={100}
           label="Monthly Income"
         />
+        <a href="/recurring" className="text-sm text-blue-500 hover:underline self-end">
+          Manage Recurring Transactions
+        </a>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- derive initial monthly cost & income from recurring totals
- link forecast controls to recurring page
- show totals on recurring page and allow editing
- improve styling for recurring transaction list

## Testing
- `bun test`
