### PR TITLE
Improve sorting and monthly totals

### DIFF
--- a/components/recurring/RecurringPageClient.tsx
+++ b/components/recurring/RecurringPageClient.tsx
@@ -5,6 +5,7 @@ import { api } from '@/convex/_generated/api';
 import { Doc, Id } from '@/convex/_generated/dataModel';
 import { Modal } from '@/components/modal';
 import { TransactionForm } from './transaction-form';
+import { monthlyAmount } from '@/lib/recurring';
 
 type Recurring = Doc<'recurringTransactions'>;
 
@@ -17,20 +18,51 @@ export default function RecurringPageClient({ initialData }: RecurringPageClient
   const remove = useMutation(api.recurring.deleteRecurringTransaction);
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState<Recurring | null>(null);
+  const [sortField, setSortField] = useState<'amount' | 'type' | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const sortedData = useMemo(() => {
+    const arr = [...data];
+    if (sortField === 'amount') {
+      arr.sort((a, b) =>
+        sortDir === 'asc' ? a.amount - b.amount : b.amount - a.amount,
+      );
+    } else if (sortField === 'type') {
+      arr.sort((a, b) => {
+        if (a.type === b.type) return 0;
+        if (sortDir === 'asc') return a.type === 'income' ? -1 : 1;
+        return a.type === 'income' ? 1 : -1;
+      });
+    } else {
+      arr.sort((a, b) => {
+        if (a.type !== b.type) {
+          return a.type === 'income' ? -1 : 1;
+        }
+        return b.amount - a.amount;
+      });
+    }
+    return arr;
+  }, [data, sortField, sortDir]);
+
   const totals = useMemo(() => {
     return data.reduce(
       (acc, t) => {
-        const monthly =
-          t.frequency === 'monthly'
-            ? t.amount * (t.daysOfMonth ? t.daysOfMonth.length : 1)
-            : t.amount / 12;
+        const monthly = monthlyAmount(t);
         if (t.type === 'income') acc.income += monthly;
         else acc.expense += monthly;
         return acc;
       },
-      { income: 0, expense: 0 }
+      { income: 0, expense: 0 },
     );
   }, [data]);
+
+  const toggleSort = (field: 'amount' | 'type') => {
+    if (sortField === field) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+  };
 
   const handleDelete = async (id: Id<'recurringTransactions'>) => {
     await remove({ id });
@@ -56,22 +88,59 @@ export default function RecurringPageClient({ initialData }: RecurringPageClient
         <thead>
           <tr>
             <th className="px-2 py-1 text-left">Name</th>
-            <th className="px-2 py-1 text-left">Amount</th>
-            <th className="px-2 py-1 text-left">Type</th>
+            <th
+              className="px-2 py-1 text-left cursor-pointer"
+              onClick={() => toggleSort('amount')}
+            >
+              Amount
+            </th>
+            <th className="px-2 py-1 text-left">Monthly Total</th>
+            <th
+              className="px-2 py-1 text-left cursor-pointer"
+              onClick={() => toggleSort('type')}
+            >
+              Type
+            </th>
             <th className="px-2 py-1 text-left">Frequency</th>
+            <th className="px-2 py-1 text-left">Tags</th>
             <th className="px-2 py-1 text-right">Actions</th>
           </tr>
         </thead>
         <tbody>
-          {data.map((t) => (
+          {sortedData.map((t) => (
             <tr key={t._id} className="border-t border-gray-700">
               <td className="px-2 py-1">{t.name}</td>
               <td className="px-2 py-1">${t.amount}</td>
-              <td className="px-2 py-1">{t.type}</td>
+              <td className="px-2 py-1">${monthlyAmount(t)}</td>
+              <td className="px-2 py-1">
+                <span
+                  className={`px-2 py-1 rounded-full text-xs ${
+                    t.type === 'income'
+                      ? 'bg-green-700 text-green-200'
+                      : 'bg-red-700 text-red-200'
+                  }`}
+                >
+                  {t.type === 'income' ? 'Income' : 'Expense'}
+                </span>
+              </td>
               <td className="px-2 py-1">
                 {t.frequency === 'monthly'
                   ? `Monthly on ${t.daysOfMonth?.join(', ')}`
                   : `Yearly on ${t.month}/${t.day}`}
+              </td>
+              <td className="px-2 py-1">
+                {t.tags && t.tags.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {t.tags.map((tag, idx) => (
+                      <span
+                        key={idx}
+                        className="px-2 py-1 bg-gray-700 rounded-full text-xs"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
               </td>
               <td className="px-2 py-1 text-right space-x-2">
                 <button

--- a/components/recurring/transaction-form.tsx
+++ b/components/recurring/transaction-form.tsx
@@ -20,6 +20,7 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
   );
   const [month, setMonth] = useState(transaction?.month ? String(transaction.month) : '');
   const [day, setDay] = useState(transaction?.day ? String(transaction.day) : '');
+  const [tags, setTags] = useState(transaction?.tags ? transaction.tags.join(',') : '');
 
   const add = useMutation(api.recurring.addRecurringTransaction);
   const update = useMutation(api.recurring.updateRecurringTransaction);
@@ -39,6 +40,11 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
     } else {
       data.month = month ? Number(month) : 1;
       data.day = day ? Number(day) : 1;
+    }
+    if (tags) {
+      data.tags = tags.split(',').map((t) => t.trim()).filter(Boolean);
+    } else {
+      data.tags = [];
     }
     if (transaction) {
       await update({ id: transaction._id, ...data });
@@ -132,6 +138,15 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
             </div>
           </div>
         )}
+        <div>
+          <label className="block text-sm mb-1">Tags (comma separated)</label>
+          <input
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="rent,utilities"
+          />
+        </div>
         <div className="flex justify-end gap-2">
           <button
             type="button"

--- a/convex/recurring.ts
+++ b/convex/recurring.ts
@@ -22,6 +22,7 @@ export const addRecurringTransaction = mutation({
     daysOfMonth: v.optional(v.array(v.number())),
     month: v.optional(v.number()),
     day: v.optional(v.number()),
+    tags: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
@@ -40,6 +41,7 @@ export const updateRecurringTransaction = mutation({
     daysOfMonth: v.optional(v.array(v.number())),
     month: v.optional(v.number()),
     day: v.optional(v.number()),
+    tags: v.optional(v.array(v.string())),
   },
   handler: async (ctx, { id, ...updates }) => {
     const userId = await getUserId(ctx);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -133,7 +133,8 @@ export default defineSchema({
     frequency: v.union(v.literal("monthly"), v.literal("yearly")),
     daysOfMonth: v.optional(v.array(v.number())),
     month: v.optional(v.number()),
-    day: v.optional(v.number())
+    day: v.optional(v.number()),
+    tags: v.optional(v.array(v.string()))
   }).index("by_user", ["userId"]),
 
   // Store user preferences

--- a/lib/recurring.ts
+++ b/lib/recurring.ts
@@ -1,0 +1,14 @@
+export function monthlyAmount(t: {
+  frequency: 'monthly' | 'yearly';
+  amount: number;
+  daysOfMonth?: number[] | null;
+}): number {
+  if (t.frequency === 'monthly') {
+    const occurrences = t.daysOfMonth && t.daysOfMonth.length > 0 ? t.daysOfMonth.length : 1;
+    return t.amount * occurrences;
+  }
+  if (t.frequency === 'yearly') {
+    return t.amount / 12;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add utility for computing recurring monthly totals
- default sort recurring table by income then amount
- display monthly total for each transaction

## Testing
- `npm test`
