### PR TITLE
Add tag filtering to recurring transactions

### DIFF
--- a/components/recurring/transaction-form.tsx
+++ b/components/recurring/transaction-form.tsx
@@ -3,14 +3,16 @@ import { useState } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Doc } from '@/convex/_generated/dataModel';
+import TagInput from '../tags/tag-input';
 
 interface TransactionFormProps {
   onClose: () => void;
   transaction?: Doc<'recurringTransactions'>;
   onSubmit?: (updates: Partial<Doc<'recurringTransactions'>>) => Promise<void>;
+  tagSuggestions?: string[];
 }
 
-export function TransactionForm({ onClose, transaction, onSubmit }: TransactionFormProps) {
+export function TransactionForm({ onClose, transaction, onSubmit, tagSuggestions = [] }: TransactionFormProps) {
   const [name, setName] = useState(transaction?.name || '');
   const [amount, setAmount] = useState(transaction?.amount.toString() || '');
   const [type, setType] = useState<'income' | 'expense'>(transaction?.type || 'expense');
@@ -140,10 +142,10 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
         )}
         <div>
           <label className="block text-sm mb-1">Tags (comma separated)</label>
-          <input
-            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+          <TagInput
             value={tags}
-            onChange={(e) => setTags(e.target.value)}
+            onChange={setTags}
+            suggestions={tagSuggestions}
             placeholder="rent,utilities"
           />
         </div>

--- a/components/tags/tag-input.tsx
+++ b/components/tags/tag-input.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { useState } from 'react';
+
+interface TagInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  suggestions: string[];
+  placeholder?: string;
+}
+
+export default function TagInput({ value, onChange, suggestions, placeholder }: TagInputProps) {
+  const [focused, setFocused] = useState(false);
+  const tokens = value.split(',').map(t => t.trim());
+  const current = tokens[tokens.length - 1] ?? '';
+  const filtered = suggestions
+    .filter(tag => tag.toLowerCase().startsWith(current.toLowerCase()) && !tokens.slice(0, -1).includes(tag));
+
+  const handleSelect = (tag: string) => {
+    const newTokens = tokens.slice(0, -1);
+    newTokens.push(tag);
+    const joined = newTokens.filter(Boolean).join(',');
+    onChange(joined);
+    setFocused(false);
+  };
+
+  return (
+    <div className="relative">
+      <input
+        className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={() => setTimeout(() => setFocused(false), 100)}
+        placeholder={placeholder}
+      />
+      {focused && current && filtered.length > 0 && (
+        <ul className="absolute z-20 bg-gray-800 border border-gray-600 mt-1 rounded-md max-h-40 overflow-auto w-full">
+          {filtered.map((tag) => (
+            <li
+              key={tag}
+              onMouseDown={() => handleSelect(tag)}
+              className="px-2 py-1 cursor-pointer hover:bg-gray-700"
+            >
+              {tag}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow filtering recurring transactions by tags and show totals only for filtered items
- show tag suggestions when filtering or editing transactions
- implement `TagInput` component with autocomplete

## Testing
- `npm test`