### PR TITLE
Add tag filtering for recurring transactions

### DIFF
--- a/app/recurring/page.tsx
+++ b/app/recurring/page.tsx
@@ -8,9 +8,13 @@ export default async function RecurringPage() {
     api.recurring.listRecurringTransactions,
     {}
   );
+  const initialTags = await preloadQueryWithAuth<string[]>(
+    api.recurring.listRecurringTags,
+    {}
+  );
   return (
     <div className="container mx-auto px-4 py-8">
-      <RecurringPageClient initialData={initialData || []} />
+      <RecurringPageClient initialData={initialData || []} initialTags={initialTags || []} />
     </div>
   );
 }

--- a/components/recurring/transaction-form.tsx
+++ b/components/recurring/transaction-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState } from 'react';
-import { useMutation } from 'convex/react';
+import { useMutation, useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Doc } from '@/convex/_generated/dataModel';
 
@@ -21,6 +21,8 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
   const [month, setMonth] = useState(transaction?.month ? String(transaction.month) : '');
   const [day, setDay] = useState(transaction?.day ? String(transaction.day) : '');
   const [tags, setTags] = useState(transaction?.tags ? transaction.tags.join(',') : '');
+
+  const existingTags = useQuery(api.recurring.listRecurringTags) ?? [];
 
   const add = useMutation(api.recurring.addRecurringTransaction);
   const update = useMutation(api.recurring.updateRecurringTransaction);
@@ -145,7 +147,13 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
             value={tags}
             onChange={(e) => setTags(e.target.value)}
             placeholder="rent,utilities"
+            list="recurring-tag-options"
           />
+          <datalist id="recurring-tag-options">
+            {existingTags.map((tag) => (
+              <option key={tag} value={tag} />
+            ))}
+          </datalist>
         </div>
         <div className="flex justify-end gap-2">
           <button

--- a/convex/recurring.ts
+++ b/convex/recurring.ts
@@ -97,3 +97,19 @@ export const getMonthlyTotals = query({
     return { monthlyIncome, monthlyCost };
   },
 });
+
+export const listRecurringTags = query({
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return [] as string[];
+    const recs = await ctx.db
+      .query("recurringTransactions")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    const tagSet = new Set<string>();
+    recs.forEach((r) => {
+      r.tags?.forEach((t: string) => tagSet.add(t));
+    });
+    return Array.from(tagSet);
+  },
+});


### PR DESCRIPTION
## Summary
- support fetching unique tags via `listRecurringTags`
- enable tag filtering on Recurring Transactions page with suggestions
- show tag suggestions when adding/editing a recurring transaction

## Testing
- `bun test`
