### PR TITLE
Add weekly and quarterly recurring options

### DIFF
--- a/__tests__/recurring.test.js
+++ b/__tests__/recurring.test.js
@@ -6,6 +6,13 @@ function monthlyAmount(t) {
     const occurrences = t.daysOfMonth ? t.daysOfMonth.length : 1;
     return t.amount * occurrences;
   }
+  if (t.frequency === 'weekly') {
+    const occurrences = t.daysOfWeek ? t.daysOfWeek.length : 1;
+    return (t.amount * occurrences * 52) / 12;
+  }
+  if (t.frequency === 'quarterly') {
+    return t.amount / 3;
+  }
   if (t.frequency === 'yearly') {
     return t.amount / 12;
   }
@@ -20,4 +27,14 @@ test('monthlyAmount handles monthly frequency with multiple days', () => {
 test('monthlyAmount handles yearly frequency', () => {
   const item = { frequency: 'yearly', amount: 120, month: 4, day: 12 };
   assert.strictEqual(monthlyAmount(item), 10);
+});
+
+test('monthlyAmount handles weekly frequency', () => {
+  const item = { frequency: 'weekly', amount: 100, daysOfWeek: [1,5] };
+  assert.strictEqual(monthlyAmount(item), (100 * 2 * 52) / 12);
+});
+
+test('monthlyAmount handles quarterly frequency', () => {
+  const item = { frequency: 'quarterly', amount: 300, month: 1, day: 1 };
+  assert.strictEqual(monthlyAmount(item), 100);
 });

--- a/components/recurring/RecurringPageClient.tsx
+++ b/components/recurring/RecurringPageClient.tsx
@@ -125,6 +125,10 @@ export default function RecurringPageClient({ initialData }: RecurringPageClient
                 <span>
                   {t.frequency === 'monthly'
                     ? `Monthly on ${t.daysOfMonth?.join(', ')}`
+                    : t.frequency === 'weekly'
+                    ? `Weekly on ${t.daysOfWeek?.join(', ')}`
+                    : t.frequency === 'quarterly'
+                    ? `Quarterly starting ${t.month}/${t.day}`
                     : `Yearly on ${t.month}/${t.day}`}
                 </span>
               </div>
@@ -188,6 +192,10 @@ export default function RecurringPageClient({ initialData }: RecurringPageClient
               <td className="px-2 py-1">
                 {t.frequency === 'monthly'
                   ? `Monthly on ${t.daysOfMonth?.join(', ')}`
+                  : t.frequency === 'weekly'
+                  ? `Weekly on ${t.daysOfWeek?.join(', ')}`
+                  : t.frequency === 'quarterly'
+                  ? `Quarterly starting ${t.month}/${t.day}`
                   : `Yearly on ${t.month}/${t.day}`}
               </td>
               <td className="px-2 py-1">

--- a/components/recurring/transaction-form.tsx
+++ b/components/recurring/transaction-form.tsx
@@ -14,9 +14,12 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
   const [name, setName] = useState(transaction?.name || '');
   const [amount, setAmount] = useState(transaction?.amount.toString() || '');
   const [type, setType] = useState<'income' | 'expense'>(transaction?.type || 'expense');
-  const [frequency, setFrequency] = useState<'monthly' | 'yearly'>(transaction?.frequency || 'monthly');
+  const [frequency, setFrequency] = useState<'monthly' | 'yearly' | 'weekly' | 'quarterly'>(transaction?.frequency || 'monthly');
   const [daysOfMonth, setDaysOfMonth] = useState(
     transaction?.daysOfMonth ? transaction.daysOfMonth.join(',') : ''
+  );
+  const [daysOfWeek, setDaysOfWeek] = useState(
+    (transaction as any)?.daysOfWeek ? (transaction as any).daysOfWeek.join(',') : ''
   );
   const [month, setMonth] = useState(transaction?.month ? String(transaction.month) : '');
   const [day, setDay] = useState(transaction?.day ? String(transaction.day) : '');
@@ -35,14 +38,18 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
     };
     if (frequency === 'monthly') {
       data.daysOfMonth = daysOfMonth
-        ? daysOfMonth.split(',').map((d) => Number(d.trim())).filter(Boolean)
+        ? daysOfMonth.split(',').map((d: string) => Number(d.trim())).filter(Boolean)
+        : [1];
+    } else if (frequency === 'weekly') {
+      data.daysOfWeek = daysOfWeek
+        ? daysOfWeek.split(',').map((d: string) => Number(d.trim())).filter(Boolean)
         : [1];
     } else {
       data.month = month ? Number(month) : 1;
       data.day = day ? Number(day) : 1;
     }
     if (tags) {
-      data.tags = tags.split(',').map((t) => t.trim()).filter(Boolean);
+      data.tags = tags.split(',').map((t: string) => t.trim()).filter(Boolean);
     } else {
       data.tags = [];
     }
@@ -96,13 +103,19 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
           <select
             className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
             value={frequency}
-            onChange={(e) => setFrequency(e.target.value as 'monthly' | 'yearly')}
+            onChange={(e) =>
+              setFrequency(
+                e.target.value as 'monthly' | 'yearly' | 'weekly' | 'quarterly'
+              )
+            }
           >
             <option value="monthly">Monthly</option>
+            <option value="weekly">Weekly</option>
+            <option value="quarterly">Quarterly</option>
             <option value="yearly">Yearly</option>
           </select>
         </div>
-        {frequency === 'monthly' ? (
+        {frequency === 'monthly' && (
           <div>
             <label className="block text-sm mb-1">Days of Month (comma separated)</label>
             <input
@@ -112,7 +125,19 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
               placeholder="1,15"
             />
           </div>
-        ) : (
+        )}
+        {frequency === 'weekly' && (
+          <div>
+            <label className="block text-sm mb-1">Days of Week (0-6 comma separated)</label>
+            <input
+              className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+              value={daysOfWeek}
+              onChange={(e) => setDaysOfWeek(e.target.value)}
+              placeholder="1,3,5"
+            />
+          </div>
+        )}
+        {(frequency === 'yearly' || frequency === 'quarterly') && (
           <div className="flex space-x-2">
             <div>
               <label className="block text-sm mb-1">Month (1-12)</label>

--- a/convex/recurring.ts
+++ b/convex/recurring.ts
@@ -18,8 +18,14 @@ export const addRecurringTransaction = mutation({
     name: v.string(),
     amount: v.number(),
     type: v.union(v.literal("income"), v.literal("expense")),
-    frequency: v.union(v.literal("monthly"), v.literal("yearly")),
+    frequency: v.union(
+      v.literal("monthly"),
+      v.literal("yearly"),
+      v.literal("weekly"),
+      v.literal("quarterly")
+    ),
     daysOfMonth: v.optional(v.array(v.number())),
+    daysOfWeek: v.optional(v.array(v.number())),
     month: v.optional(v.number()),
     day: v.optional(v.number()),
     tags: v.optional(v.array(v.string())),
@@ -37,8 +43,16 @@ export const updateRecurringTransaction = mutation({
     name: v.optional(v.string()),
     amount: v.optional(v.number()),
     type: v.optional(v.union(v.literal("income"), v.literal("expense"))),
-    frequency: v.optional(v.union(v.literal("monthly"), v.literal("yearly"))),
+    frequency: v.optional(
+      v.union(
+        v.literal("monthly"),
+        v.literal("yearly"),
+        v.literal("weekly"),
+        v.literal("quarterly")
+      )
+    ),
     daysOfMonth: v.optional(v.array(v.number())),
+    daysOfWeek: v.optional(v.array(v.number())),
     month: v.optional(v.number()),
     day: v.optional(v.number()),
     tags: v.optional(v.array(v.string())),
@@ -72,6 +86,13 @@ export function monthlyAmount(t: any): number {
   if (t.frequency === "monthly") {
     const occurrences = t.daysOfMonth ? t.daysOfMonth.length : 1;
     return t.amount * occurrences;
+  }
+  if (t.frequency === "weekly") {
+    const occurrences = t.daysOfWeek ? t.daysOfWeek.length : 1;
+    return (t.amount * occurrences * 52) / 12;
+  }
+  if (t.frequency === "quarterly") {
+    return t.amount / 3;
   }
   if (t.frequency === "yearly") {
     return t.amount / 12;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -130,8 +130,14 @@ export default defineSchema({
     name: v.string(),
     amount: v.number(),
     type: v.union(v.literal("income"), v.literal("expense")),
-    frequency: v.union(v.literal("monthly"), v.literal("yearly")),
+    frequency: v.union(
+      v.literal("monthly"),
+      v.literal("yearly"),
+      v.literal("weekly"),
+      v.literal("quarterly")
+    ),
     daysOfMonth: v.optional(v.array(v.number())),
+    daysOfWeek: v.optional(v.array(v.number())),
     month: v.optional(v.number()),
     day: v.optional(v.number()),
     tags: v.optional(v.array(v.string()))

--- a/lib/recurring.ts
+++ b/lib/recurring.ts
@@ -1,11 +1,19 @@
 export function monthlyAmount(t: {
-  frequency: 'monthly' | 'yearly';
+  frequency: 'monthly' | 'yearly' | 'weekly' | 'quarterly';
   amount: number;
   daysOfMonth?: number[] | null;
+  daysOfWeek?: number[] | null;
 }): number {
   if (t.frequency === 'monthly') {
     const occurrences = t.daysOfMonth && t.daysOfMonth.length > 0 ? t.daysOfMonth.length : 1;
     return t.amount * occurrences;
+  }
+  if (t.frequency === 'weekly') {
+    const occurrences = t.daysOfWeek && t.daysOfWeek.length > 0 ? t.daysOfWeek.length : 1;
+    return (t.amount * occurrences * 52) / 12;
+  }
+  if (t.frequency === 'quarterly') {
+    return t.amount / 3;
   }
   if (t.frequency === 'yearly') {
     return t.amount / 12;


### PR DESCRIPTION
## Summary
- support `weekly` and `quarterly` recurring transaction frequencies
- handle new options in Convex schema and mutations
- extend transaction form and UI to manage weekly and quarterly cases
- update monthlyAmount helper and tests
- fix TypeScript compile errors in transaction form

## Testing
- `npm test`
- `npm run build`
