### PR TITLE
Add one-time transactions

### DIFF
--- a/app/one-time/page.tsx
+++ b/app/one-time/page.tsx
@@ -1,0 +1,20 @@
+import { api } from '@/convex/_generated/api';
+import { Doc } from '@/convex/_generated/dataModel';
+import { preloadQueryWithAuth } from '@/lib/convex';
+import OneTimePageClient from '@/components/oneTime/OneTimePageClient';
+
+export default async function OneTimePage() {
+  const initialData = await preloadQueryWithAuth<Doc<'oneTimeTransactions'>[]>(
+    api.oneTime.listOneTimeTransactions,
+    {}
+  );
+  const initialTags = await preloadQueryWithAuth<string[]>(
+    api.oneTime.listOneTimeTags,
+    {}
+  );
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <OneTimePageClient initialData={initialData || []} initialTags={initialTags || []} />
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,14 +12,19 @@ type Wallet = Doc<'wallets'>;
 import WalletsCard from "@/components/cards/wallets-card";
 import AssetsCard from "@/components/cards/assets-card";
 import DebtsCard from "@/components/cards/debts-card";
+import OneTimeCard from "@/components/cards/one-time-card";
 
 export default async function Home() {
   // Preload all data with authentication
-  const [forecastData, assetsPreload, debtsPreload, walletsPreload] = await Promise.all([
+  const [forecastData, assetsPreload, debtsPreload, walletsPreload, oneTimePreload] = await Promise.all([
     preloadForecastData(),
     preloadQueryWithAuth<Asset[]>(api.assets.listAssets, {}),
     preloadQueryWithAuth<Debt[]>(api.debts.listDebts, {}),
-    preloadQueryWithAuth<Wallet[]>(api.wallets.listWallets, {})
+    preloadQueryWithAuth<Wallet[]>(api.wallets.listWallets, {}),
+    preloadQueryWithAuth<Doc<'oneTimeTransactions'>[]>(
+      api.oneTime.listOneTimeTransactions,
+      {},
+    )
   ]);
 
   return (
@@ -39,10 +44,11 @@ export default async function Home() {
           initialRecurring={forecastData.initialRecurring as { monthlyIncome: number; monthlyCost: number } | null}
         />
       </div>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8 w-full">
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-8 w-full">
           <WalletsCard wallets={walletsPreload || []} />
           <AssetsCard assets={assetsPreload || []} />
           <DebtsCard debts={debtsPreload || []} />
+          <OneTimeCard items={oneTimePreload || []} />
         </div>
       </div>
     </div>

--- a/components/cards/one-time-card.tsx
+++ b/components/cards/one-time-card.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Doc } from '@/convex/_generated/dataModel';
+import { PlusIcon } from '@heroicons/react/24/outline';
+import { useState, useMemo } from 'react';
+import { Modal } from '@/components/modal';
+import { TransactionForm } from '@/components/oneTime/transaction-form';
+import { formatNumber } from '@/lib/formatters';
+
+type OneTime = Doc<'oneTimeTransactions'>;
+
+interface OneTimeCardProps {
+  items: OneTime[];
+}
+
+export default function OneTimeCard({ items: initialItems }: OneTimeCardProps) {
+  const items = useQuery(api.oneTime.listOneTimeTransactions) ?? initialItems;
+  const [showAddForm, setShowAddForm] = useState(false);
+
+  const currentYear = new Date().getFullYear();
+
+  const total = useMemo(() => {
+    if (!items) return 0;
+    return items
+      .filter((i) => new Date(i.date).getFullYear() === currentYear && i.type === 'expense')
+      .reduce((sum, t) => sum + t.amount, 0);
+  }, [items, currentYear]);
+
+  const sorted = useMemo(() => {
+    if (!items) return [];
+    return [...items]
+      .filter((i) => new Date(i.date).getFullYear() === currentYear)
+      .sort((a, b) => b.date - a.date)
+      .slice(0, 5);
+  }, [items, currentYear]);
+
+  return (
+    <div className="relative bg-white/5 rounded-lg p-6 backdrop-blur-sm">
+      <h2 className="text-xl font-semibold mb-1">One Time Expenses ({currentYear})</h2>
+      <span className="block text-red-500 font-mono mb-4">
+        {`Total: $${formatNumber(total)}`}
+      </span>
+      <button
+        onClick={() => setShowAddForm(true)}
+        className="absolute top-2 right-2 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800"
+      >
+        <PlusIcon className="w-5 h-5" />
+      </button>
+
+      <div className="space-y-3">
+        {sorted.length === 0 ? (
+          <p className="text-gray-400 text-center py-4">No expenses added.</p>
+        ) : (
+          sorted.map((t) => (
+            <div key={t._id} className="flex justify-between items-center p-3 bg-gray-800/50 rounded-lg">
+              <span>{t.name}</span>
+              <span className="font-mono">${formatNumber(t.amount)}</span>
+            </div>
+          ))
+        )}
+      </div>
+
+      {showAddForm && (
+        <Modal onClose={() => setShowAddForm(false)}>
+          <TransactionForm onClose={() => setShowAddForm(false)} />
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/components/forecast/ForecastControls.tsx
+++ b/components/forecast/ForecastControls.tsx
@@ -28,9 +28,14 @@ export function ForecastControls({
         step={100}
         label="Monthly Income"
       />
-      <a href="/recurring" className="text-sm text-blue-500 hover:underline self-end">
-        Manage Recurring Transactions
-      </a>
+      <div className="flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-end">
+        <a href="/recurring" className="text-sm text-blue-500 hover:underline">
+          Manage Recurring Transactions
+        </a>
+        <a href="/one-time" className="text-sm text-blue-500 hover:underline">
+          Manage One Time Transactions
+        </a>
+      </div>
     </div>
   );
 }

--- a/components/forecast/ForecastEmptyState.tsx
+++ b/components/forecast/ForecastEmptyState.tsx
@@ -44,10 +44,15 @@ export function ForecastEmptyState({
           step={100}
           label="Monthly Income"
         />
-        <a href="/recurring" className="text-sm text-blue-500 hover:underline self-end">
-          Manage Recurring Transactions
-        </a>
+        <div className="flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-end">
+          <a href="/recurring" className="text-sm text-blue-500 hover:underline">
+            Manage Recurring Transactions
+          </a>
+          <a href="/one-time" className="text-sm text-blue-500 hover:underline">
+            Manage One Time Transactions
+          </a>
+        </div>
       </div>
     </div>
   );
-} 
+}

--- a/components/oneTime/OneTimePageClient.tsx
+++ b/components/oneTime/OneTimePageClient.tsx
@@ -1,0 +1,271 @@
+'use client';
+import { useState, useMemo } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Doc, Id } from '@/convex/_generated/dataModel';
+import { Modal } from '@/components/modal';
+import { TransactionForm } from './transaction-form';
+import { PencilIcon, TrashIcon, PlusIcon } from '@heroicons/react/24/outline';
+
+type OneTime = Doc<'oneTimeTransactions'>;
+
+interface OneTimePageClientProps {
+  initialData: OneTime[];
+  initialTags: string[];
+}
+
+export default function OneTimePageClient({ initialData, initialTags }: OneTimePageClientProps) {
+  const data = useQuery(api.oneTime.listOneTimeTransactions) ?? initialData;
+  const allTags = useQuery(api.oneTime.listOneTimeTags) ?? initialTags;
+  const remove = useMutation(api.oneTime.deleteOneTimeTransaction);
+  const [showForm, setShowForm] = useState(false);
+  const [editing, setEditing] = useState<OneTime | null>(null);
+  const [sortField, setSortField] = useState<'amount' | 'date' | 'type' | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+  const [tagFilter, setTagFilter] = useState('');
+
+  const filteredData = useMemo(() => {
+    const tags = tagFilter
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    if (tags.length === 0) return data;
+    return data.filter((t) => tags.every((tag) => t.tags?.includes(tag)));
+  }, [data, tagFilter]);
+
+  const sortedData = useMemo(() => {
+    const arr = [...filteredData];
+    if (sortField === 'amount') {
+      arr.sort((a, b) => (sortDir === 'asc' ? a.amount - b.amount : b.amount - a.amount));
+    } else if (sortField === 'date') {
+      arr.sort((a, b) => (sortDir === 'asc' ? a.date - b.date : b.date - a.date));
+    } else if (sortField === 'type') {
+      arr.sort((a, b) => {
+        if (a.type === b.type) return 0;
+        if (sortDir === 'asc') return a.type === 'income' ? -1 : 1;
+        return a.type === 'income' ? 1 : -1;
+      });
+    } else {
+      arr.sort((a, b) => b.date - a.date);
+    }
+    return arr;
+  }, [filteredData, sortField, sortDir]);
+
+  const totals = useMemo(() => {
+    const result = filteredData.reduce(
+      (acc, t) => {
+        if (t.type === 'income') acc.income += t.amount;
+        else acc.expense += t.amount;
+        return acc;
+      },
+      { income: 0, expense: 0 },
+    );
+    return {
+      ...result,
+      net: result.income - result.expense,
+    };
+  }, [filteredData]);
+
+  const toggleSort = (field: 'amount' | 'date' | 'type') => {
+    if (sortField === field) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+  };
+
+  const handleDelete = async (id: Id<'oneTimeTransactions'>) => {
+    await remove({ id });
+  };
+
+  const handleEdit = (item: OneTime) => {
+    setEditing(item);
+    setShowForm(true);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 max-w-3xl mx-auto relative">
+      <div className="flex justify-between items-center gap-2 flex-wrap">
+        <h1 className="text-2xl font-bold">One Time Transactions</h1>
+        <div className="flex items-center gap-2">
+          <input
+            value={tagFilter}
+            onChange={(e) => setTagFilter(e.target.value)}
+            list="one-time-tag-filter"
+            placeholder="Filter tags"
+            className="px-2 py-1 rounded-md border border-gray-600 bg-gray-800"
+          />
+          <datalist id="one-time-tag-filter">
+            {allTags.map((tag) => (
+              <option key={tag} value={tag} />
+            ))}
+          </datalist>
+          <button
+            onClick={() => setShowForm(true)}
+            className="hidden sm:flex items-center gap-1 px-4 py-2 rounded-md bg-blue-600 text-white"
+          >
+            <PlusIcon className="w-5 h-5" />
+            <span>Add</span>
+          </button>
+        </div>
+      </div>
+      {/* Mobile card list */}
+      <div className="md:hidden space-y-3">
+        {sortedData.map((t) => (
+          <div key={t._id} className="bg-white/5 rounded-lg p-4 space-y-2">
+            <div className="flex justify-between items-center">
+              <span className="font-medium">{t.name}</span>
+              <div className="flex space-x-2">
+                <button
+                  onClick={() => handleEdit(t)}
+                  className="p-1 rounded hover:bg-gray-700"
+                >
+                  <PencilIcon className="w-5 h-5 text-blue-400" />
+                </button>
+                <button
+                  onClick={() => handleDelete(t._id)}
+                  className="p-1 rounded hover:bg-gray-700"
+                >
+                  <TrashIcon className="w-5 h-5 text-red-400" />
+                </button>
+              </div>
+            </div>
+            <div className="text-sm space-y-1">
+              <div className="flex justify-between">
+                <span>Amount</span>
+                <span className="font-mono">${t.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Date</span>
+                <span>{new Date(t.date).toLocaleDateString()}</span>
+              </div>
+              <div className="flex justify-between">
+                <span>Type</span>
+                <span>{t.type === 'income' ? 'Income' : 'Expense'}</span>
+              </div>
+              {t.tags && t.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  {t.tags.map((tag, idx) => (
+                    <span
+                      key={idx}
+                      className="px-2 py-1 bg-gray-700 rounded-full text-xs"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* Desktop table */}
+      <div className="hidden md:block overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr>
+              <th className="px-2 py-1 text-left">Name</th>
+              <th
+                className="px-2 py-1 text-left cursor-pointer"
+                onClick={() => toggleSort('amount')}
+              >
+                Amount
+              </th>
+              <th
+                className="px-2 py-1 text-left cursor-pointer"
+                onClick={() => toggleSort('date')}
+              >
+                Date
+              </th>
+              <th
+                className="px-2 py-1 text-left cursor-pointer"
+                onClick={() => toggleSort('type')}
+              >
+                Type
+              </th>
+              <th className="px-2 py-1 text-left">Tags</th>
+              <th className="px-2 py-1 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedData.map((t) => (
+              <tr key={t._id} className="border-t border-gray-700">
+                <td className="px-2 py-1">{t.name}</td>
+                <td className="px-2 py-1">${t.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td className="px-2 py-1">{new Date(t.date).toLocaleDateString()}</td>
+                <td className="px-2 py-1">
+                  <span
+                    className={`px-2 py-1 rounded-full text-xs ${
+                      t.type === 'income'
+                        ? 'bg-green-700 text-green-200'
+                        : 'bg-red-700 text-red-200'
+                    }`}
+                  >
+                    {t.type === 'income' ? 'Income' : 'Expense'}
+                  </span>
+                </td>
+                <td className="px-2 py-1">
+                  {t.tags && t.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {t.tags.map((tag, idx) => (
+                        <span
+                          key={idx}
+                          className="px-2 py-1 bg-gray-700 rounded-full text-xs"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </td>
+                <td className="px-2 py-1 text-right space-x-2">
+                  <button
+                    onClick={() => handleEdit(t)}
+                    className="p-1 rounded hover:bg-gray-700"
+                    title="Edit"
+                  >
+                    <PencilIcon className="w-5 h-5 text-blue-400" />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(t._id)}
+                    className="p-1 rounded hover:bg-gray-700"
+                    title="Delete"
+                  >
+                    <TrashIcon className="w-5 h-5 text-red-400" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="flex flex-col items-end gap-1 text-sm mt-2">
+          <div>
+            Total Income: <span className="text-green-500">${totals.income.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          </div>
+          <div>
+            Total Expenses: <span className="text-red-500">${totals.expense.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          </div>
+          <div>
+            Net: <span className={totals.net >= 0 ? 'text-green-500' : 'text-red-500'}>${totals.net.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          </div>
+        </div>
+      </div>
+      <button
+        onClick={() => setShowForm(true)}
+        className="sm:hidden fixed bottom-4 right-4 p-4 rounded-full bg-blue-600 text-white shadow-lg"
+        aria-label="Add one time transaction"
+      >
+        <PlusIcon className="w-6 h-6" />
+      </button>
+      {showForm && (
+        <Modal onClose={() => { setShowForm(false); setEditing(null); }}>
+          <TransactionForm
+            onClose={() => { setShowForm(false); setEditing(null); }}
+            transaction={editing || undefined}
+          />
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/components/oneTime/transaction-form.tsx
+++ b/components/oneTime/transaction-form.tsx
@@ -1,0 +1,124 @@
+'use client';
+import { useState } from 'react';
+import { useMutation, useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Doc } from '@/convex/_generated/dataModel';
+
+interface TransactionFormProps {
+  onClose: () => void;
+  transaction?: Doc<'oneTimeTransactions'>;
+  onSubmit?: (updates: Partial<Doc<'oneTimeTransactions'>>) => Promise<void>;
+}
+
+export function TransactionForm({ onClose, transaction, onSubmit }: TransactionFormProps) {
+  const [name, setName] = useState(transaction?.name || '');
+  const [amount, setAmount] = useState(transaction?.amount.toString() || '');
+  const [type, setType] = useState<'income' | 'expense'>(transaction?.type || 'expense');
+  const [date, setDate] = useState(
+    transaction?.date ? new Date(transaction.date).toISOString().slice(0, 10) : ''
+  );
+  const [tags, setTags] = useState(transaction?.tags ? transaction.tags.join(',') : '');
+
+  const existingTags = useQuery(api.oneTime.listOneTimeTags) ?? [];
+
+  const add = useMutation(api.oneTime.addOneTimeTransaction);
+  const update = useMutation(api.oneTime.updateOneTimeTransaction);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: any = {
+      name,
+      amount: Number(amount),
+      type,
+      date: date ? new Date(date).getTime() : Date.now(),
+    };
+    if (tags) {
+      data.tags = tags.split(',').map((t: string) => t.trim()).filter(Boolean);
+    } else {
+      data.tags = [];
+    }
+    if (transaction) {
+      await update({ id: transaction._id, ...data });
+      if (onSubmit) await onSubmit(data);
+    } else {
+      await add(data);
+    }
+    onClose();
+  };
+
+  return (
+    <div>
+      <h3 className="text-lg font-medium mb-4">
+        {transaction ? 'Edit One Time Transaction' : 'Add One Time Transaction'}
+      </h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm mb-1">Name</label>
+          <input
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Amount</label>
+          <input
+            type="number"
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Type</label>
+          <select
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+            value={type}
+            onChange={(e) => setType(e.target.value as 'income' | 'expense')}
+          >
+            <option value="income">Income</option>
+            <option value="expense">Expense</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Date</label>
+          <input
+            type="date"
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Tags (comma separated)</label>
+          <input
+            className="w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2"
+            value={tags}
+            onChange={(e) => setTags(e.target.value)}
+            placeholder="travel,gifts"
+            list="one-time-tag-options"
+          />
+          <datalist id="one-time-tag-options">
+            {existingTags.map((tag) => (
+              <option key={tag} value={tag} />
+            ))}
+          </datalist>
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-md bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button type="submit" className="px-4 py-2 rounded-md bg-blue-600 text-white">
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as holdingsNode from "../holdingsNode.js";
 import type * as metrics from "../metrics.js";
 import type * as quoteActions from "../quoteActions.js";
 import type * as quotes from "../quotes.js";
+import type * as oneTime from "../oneTime.js";
 import type * as recurring from "../recurring.js";
 import type * as userPreferences from "../userPreferences.js";
 import type * as users from "../users.js";
@@ -43,6 +44,7 @@ declare const fullApi: ApiFromModules<{
   metrics: typeof metrics;
   quoteActions: typeof quoteActions;
   quotes: typeof quotes;
+  oneTime: typeof oneTime;
   recurring: typeof recurring;
   userPreferences: typeof userPreferences;
   users: typeof users;

--- a/convex/oneTime.ts
+++ b/convex/oneTime.ts
@@ -1,0 +1,102 @@
+import { query, mutation } from "./_generated/server";
+import { v } from "convex/values";
+import { getUserId } from "./users";
+
+export const listOneTimeTransactions = query({
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return [];
+    return await ctx.db
+      .query("oneTimeTransactions")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+  },
+});
+
+export const addOneTimeTransaction = mutation({
+  args: {
+    name: v.string(),
+    amount: v.number(),
+    type: v.union(v.literal("income"), v.literal("expense")),
+    date: v.number(),
+    tags: v.optional(v.array(v.string())),
+  },
+  handler: async (ctx, args) => {
+    const userId = await getUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    return await ctx.db.insert("oneTimeTransactions", { ...args, userId });
+  },
+});
+
+export const updateOneTimeTransaction = mutation({
+  args: {
+    id: v.id("oneTimeTransactions"),
+    name: v.optional(v.string()),
+    amount: v.optional(v.number()),
+    type: v.optional(v.union(v.literal("income"), v.literal("expense"))),
+    date: v.optional(v.number()),
+    tags: v.optional(v.array(v.string())),
+  },
+  handler: async (ctx, { id, ...updates }) => {
+    const userId = await getUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    const existing = await ctx.db.get(id);
+    if (!existing || existing.userId !== userId) {
+      throw new Error("Not authorized");
+    }
+    return await ctx.db.patch(id, updates);
+  },
+});
+
+export const deleteOneTimeTransaction = mutation({
+  args: { id: v.id("oneTimeTransactions") },
+  handler: async (ctx, { id }) => {
+    const userId = await getUserId(ctx);
+    if (!userId) throw new Error("Not authenticated");
+    const existing = await ctx.db.get(id);
+    if (!existing || existing.userId !== userId) {
+      throw new Error("Not authorized");
+    }
+    await ctx.db.delete(id);
+    return true;
+  },
+});
+
+export const listOneTimeTags = query({
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return [] as string[];
+    const items = await ctx.db
+      .query("oneTimeTransactions")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    const tagSet = new Set<string>();
+    items.forEach((r) => {
+      r.tags?.forEach((t: string) => tagSet.add(t));
+    });
+    return Array.from(tagSet);
+  },
+});
+
+export const getYearlyTotals = query({
+  args: { year: v.number() },
+  handler: async (ctx, { year }) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return { income: 0, expense: 0 };
+    const start = new Date(year, 0, 1).getTime();
+    const end = new Date(year + 1, 0, 1).getTime();
+    const items = await ctx.db
+      .query("oneTimeTransactions")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    let income = 0;
+    let expense = 0;
+    items.forEach((i) => {
+      if (i.date >= start && i.date < end) {
+        if (i.type === "income") income += i.amount;
+        else expense += i.amount;
+      }
+    });
+    return { income, expense };
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -143,6 +143,16 @@ export default defineSchema({
     tags: v.optional(v.array(v.string()))
   }).index("by_user", ["userId"]),
 
+  // Store one time income or expense transactions
+  oneTimeTransactions: defineTable({
+    userId: v.string(),
+    name: v.string(),
+    amount: v.number(),
+    type: v.union(v.literal("income"), v.literal("expense")),
+    date: v.number(), // Unix timestamp
+    tags: v.optional(v.array(v.string())),
+  }).index("by_user", ["userId"]),
+
   // Store user preferences
   userPreferences: defineTable({
     userId: v.string(), // Clerk user ID


### PR DESCRIPTION
## Summary
- allow managing one-time income/expense entries
- show yearly one-time expense totals on dashboard
- link to new management page from forecast controls
- fix TypeScript error in dashboard preload

## Testing
- `npm run build`
- `npm test`
