### PR TITLE
Fix currency formatting on dashboard

### DIFF
--- a/components/asset/asset-details.tsx
+++ b/components/asset/asset-details.tsx
@@ -9,6 +9,7 @@ import { AssetForm } from '@/components/forms/asset-form';
 import { ArrowLeftIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { formatCurrency } from '@/lib/formatters';
 
 interface AssetDetailsProps {
   asset: Doc<"assets">;
@@ -99,13 +100,13 @@ export default function AssetDetails({ asset: initialAsset }: AssetDetailsProps)
             
             <div>
               <h3 className="text-sm font-medium text-gray-400">Value</h3>
-              <p className="text-lg text-green-500">${liveAsset.value.toLocaleString()}</p>
+              <p className="text-lg text-green-500">{formatCurrency(liveAsset.value)}</p>
             </div>
             
             {liveAsset.metadata?.purchasePrice !== undefined && (
               <div>
                 <h3 className="text-sm font-medium text-gray-400">Purchase Price</h3>
-                <p className="text-lg">${liveAsset.metadata.purchasePrice.toLocaleString()}</p>
+                <p className="text-lg">{formatCurrency(liveAsset.metadata.purchasePrice)}</p>
               </div>
             )}
             

--- a/components/debt/debt-details.tsx
+++ b/components/debt/debt-details.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { DebtForm } from '@/components/forms/debt-form';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { formatCurrency } from '@/lib/formatters';
 
 type Debt = Doc<"debts">;
 
@@ -102,13 +103,13 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
             
             <div>
               <h3 className="text-sm font-medium text-gray-400">Value</h3>
-              <p className="text-lg text-red-500">${liveDebt.value.toLocaleString()}</p>
+              <p className="text-lg text-red-500">{formatCurrency(liveDebt.value)}</p>
             </div>
             
             {liveDebt.metadata?.originalAmount && (
               <div>
                 <h3 className="text-sm font-medium text-gray-400">Original Amount</h3>
-                <p className="text-lg">${liveDebt.metadata.originalAmount.toLocaleString()}</p>
+                <p className="text-lg">{formatCurrency(liveDebt.metadata.originalAmount)}</p>
               </div>
             )}
             
@@ -145,7 +146,7 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
             {liveDebt.metadata?.minimumPayment !== undefined && (
               <div>
                 <h3 className="text-sm font-medium text-gray-400">Minimum Payment</h3>
-                <p className="text-lg">${liveDebt.metadata.minimumPayment.toLocaleString()}</p>
+                <p className="text-lg">{formatCurrency(liveDebt.metadata.minimumPayment)}</p>
               </div>
             )}
           </div>

--- a/components/forecast/ForecastSummary.tsx
+++ b/components/forecast/ForecastSummary.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ForecastSummaryProps } from './types';
+import { formatCurrency } from '@/lib/formatters';
 
 export function ForecastSummary({
   currentNetWorth,
@@ -25,11 +26,11 @@ export function ForecastSummary({
           <span className="hidden sm:inline">Current Net Worth</span>
         </div>
         <div className="text-xl sm:text-2xl font-bold">
-          ${(currentNetWorth || 0).toLocaleString()}
+          {formatCurrency(currentNetWorth || 0)}
         </div>
         {hasPrev && (
           <div className={`text-sm ${dayUp ? 'text-green-600' : 'text-red-600'}`}> 
-            {dayUp ? '+' : '-'}${Math.abs(dayChange).toLocaleString()} ({dayPercent}% )
+            {dayUp ? '+' : '-'}{formatCurrency(Math.abs(dayChange))} ({dayPercent}% )
             <span className="text-gray-500"> since yesterday</span>
           </div>
         )}
@@ -38,7 +39,7 @@ export function ForecastSummary({
         <div className="text-sm text-gray-500">Projected Change</div>
         <div className="text-xl sm:text-2xl font-bold text-green-600">
           <span>+{percentChange}%</span>
-          <span className="hidden sm:inline"> (+${difference.toLocaleString()})</span>
+          <span className="hidden sm:inline"> (+{formatCurrency(difference)})</span>
         </div>
       </div>
       <div className="text-center sm:text-right">
@@ -47,7 +48,7 @@ export function ForecastSummary({
           <span className="hidden sm:inline">Projected Net Worth (1 Year)</span>
         </div>
         <div className="text-xl sm:text-2xl font-bold">
-          ${(projectedNetWorth || 0).toLocaleString()}
+          {formatCurrency(projectedNetWorth || 0)}
         </div>
       </div>
     </div>

--- a/components/forecast/Slider.tsx
+++ b/components/forecast/Slider.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import { SliderProps } from './types';
+import { formatCurrency } from '@/lib/formatters';
 
 export function Slider({ value, onChange, min, max, step, label }: SliderProps) {
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center justify-between">
         <label>{label}</label>
-        <span>${value.toLocaleString()}</span>
+        <span>{formatCurrency(value)}</span>
       </div>
       <input
         type="range"

--- a/components/net-worth-chart.tsx
+++ b/components/net-worth-chart.tsx
@@ -14,6 +14,7 @@ import {
 } from 'recharts';
 
 import { Doc } from "@/convex/_generated/dataModel";
+import { formatCurrency } from '@/lib/formatters';
 
 type DailyMetric = Doc<'dailyMetrics'> & {
   isProjected?: boolean;
@@ -239,9 +240,9 @@ export default function NetWorthChart({ metrics, showUncertainty = true }: NetWo
             domain={['auto', 'auto']}
             tickFormatter={(timestamp) => new Date(timestamp).toLocaleDateString()}
           />
-          <YAxis 
+          <YAxis
             domain={yAxisDomain}
-            tickFormatter={(value) => `$${value.toLocaleString()}`}
+            tickFormatter={(value) => formatCurrency(value)}
             tickCount={8} // Suggest number of ticks
           />
           <Tooltip 
@@ -251,7 +252,7 @@ export default function NetWorthChart({ metrics, showUncertainty = true }: NetWo
                 upperProjection: 'Optimistic Projection',
                 lowerProjection: 'Pessimistic Projection'
               }[name] || name;
-              return [`$${value.toLocaleString()}`, label];
+              return [formatCurrency(value), label];
             }}
             labelFormatter={(timestamp) => new Date(timestamp).toLocaleString()}
             contentStyle={{ 

--- a/components/quotes-ticker.tsx
+++ b/components/quotes-ticker.tsx
@@ -4,6 +4,7 @@ import { useQuery } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { useEffect, useState, useRef, useMemo } from 'react';
 import { PlayIcon, PauseIcon } from '@heroicons/react/24/outline';
+import { formatCurrency } from '@/lib/formatters';
 
 export default function QuotesTicker() {
   const quotes = useQuery(api.quotes.listQuotes) || [];
@@ -40,10 +41,7 @@ export default function QuotesTicker() {
       const priceChange = quote.price - prevPrice;
       const percentChange = prevPrice ? (priceChange / prevPrice) * 100 : 0;
       const isUp = priceChange >= 0;
-      const formattedPrice = quote.price.toLocaleString(undefined, { 
-        minimumFractionDigits: 2, 
-        maximumFractionDigits: 2 
-      });
+      const formattedPrice = formatCurrency(quote.price);
       const formattedPercent = Math.abs(percentChange).toFixed(2);
       
       // Add color spans for up/down indicators
@@ -51,7 +49,7 @@ export default function QuotesTicker() {
       const arrow = isUp ? '▲' : '▼';
       
       // Create a single quote element
-      const quoteElement = `<span class="ticker-item">${quote.symbol}: $${formattedPrice} <span class="${colorClass}">${arrow} ${formattedPercent}%</span></span>`;
+      const quoteElement = `<span class="ticker-item">${quote.symbol}: ${formattedPrice} <span class="${colorClass}">${arrow} ${formattedPercent}%</span></span>`;
       quoteElements.push(quoteElement);
     });
     

--- a/components/quotes/quotes-manager.tsx
+++ b/components/quotes/quotes-manager.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { Doc } from "@/convex/_generated/dataModel";
 import { EyeIcon, EyeSlashIcon, ArrowUpIcon, ArrowDownIcon } from '@heroicons/react/24/outline';
+import { formatCurrency } from '@/lib/formatters';
 
 type Quote = Doc<"quotes">;
 
@@ -165,7 +166,7 @@ export default function QuotesManager({ initialQuotes }: QuotesManagerProps) {
                 filteredAndSortedQuotes.map((quote) => (
                   <tr key={quote._id} className="border-t border-gray-800 hover:bg-gray-800/50">
                     <td className="px-4 py-3 font-medium">{quote.symbol}</td>
-                    <td className="px-4 py-3 text-right font-mono">${quote.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                    <td className="px-4 py-3 text-right font-mono">{formatCurrency(quote.price)}</td>
                     <td className="px-4 py-3 text-gray-400 text-sm">
                       {new Date(quote.lastUpdated).toLocaleString()}
                     </td>

--- a/components/recurring/RecurringPageClient.tsx
+++ b/components/recurring/RecurringPageClient.tsx
@@ -7,6 +7,7 @@ import { Modal } from '@/components/modal';
 import { TransactionForm } from './transaction-form';
 import { monthlyAmount } from '@/lib/recurring';
 import { PencilIcon, TrashIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { formatCurrency } from '@/lib/formatters';
 
 type Recurring = Doc<'recurringTransactions'>;
 
@@ -139,11 +140,11 @@ export default function RecurringPageClient({ initialData, initialTags }: Recurr
             <div className="text-sm space-y-1">
               <div className="flex justify-between">
                 <span>Amount</span>
-                <span className="font-mono">${t.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                <span className="font-mono">{formatCurrency(t.amount)}</span>
               </div>
               <div className="flex justify-between">
                 <span>Monthly</span>
-                <span className="font-mono">${monthlyAmount(t).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+                <span className="font-mono">{formatCurrency(monthlyAmount(t))}</span>
               </div>
               <div className="flex justify-between">
                 <span>Type</span>
@@ -205,8 +206,8 @@ export default function RecurringPageClient({ initialData, initialTags }: Recurr
           {sortedData.map((t) => (
             <tr key={t._id} className="border-t border-gray-700">
               <td className="px-2 py-1">{t.name}</td>
-              <td className="px-2 py-1">${t.amount.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
-              <td className="px-2 py-1">${monthlyAmount(t).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+              <td className="px-2 py-1">{formatCurrency(t.amount)}</td>
+              <td className="px-2 py-1">{formatCurrency(monthlyAmount(t))}</td>
               <td className="px-2 py-1">
                 <span
                   className={`px-2 py-1 rounded-full text-xs ${
@@ -263,13 +264,13 @@ export default function RecurringPageClient({ initialData, initialTags }: Recurr
       </table>
       <div className="flex flex-col items-end gap-1 text-sm mt-2">
         <div>
-          Total Income: <span className="text-green-500">${totals.income.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          Total Income: <span className="text-green-500">{formatCurrency(totals.income)}</span>
         </div>
         <div>
-          Total Expenses: <span className="text-red-500">${totals.expense.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          Total Expenses: <span className="text-red-500">{formatCurrency(totals.expense)}</span>
         </div>
         <div>
-          Net Income: <span className={totals.net >= 0 ? 'text-green-500' : 'text-red-500'}>${totals.net.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+          Net Income: <span className={totals.net >= 0 ? 'text-green-500' : 'text-red-500'}>{formatCurrency(totals.net)}</span>
         </div>
       </div>
       </div>

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -28,4 +28,11 @@ export function formatNumber(num: number): string {
   
   // Otherwise use regular formatting
   return num.toLocaleString();
-} 
+}
+
+/**
+ * Format a currency value using the user's locale
+ */
+export function formatCurrency(amount: number, currency: string = 'USD'): string {
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount);
+}


### PR DESCRIPTION
## Summary
- add `formatCurrency` helper
- use `formatCurrency` anywhere dollar amounts are displayed
- correct double dollar sign in quotes ticker

## Testing
- `npm test`
