### PR TITLE
Add unified transactions page

### DIFF
--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -1,0 +1,23 @@
+import { api } from '@/convex/_generated/api';
+import { Doc } from '@/convex/_generated/dataModel';
+import { preloadQueryWithAuth } from '@/lib/convex';
+import TransactionsPageClient from '@/components/transactions/TransactionsPageClient';
+
+export default async function TransactionsPage() {
+  const [recurringData, recurringTags, oneTimeData, oneTimeTags] = await Promise.all([
+    preloadQueryWithAuth<Doc<'recurringTransactions'>[]>(api.recurring.listRecurringTransactions, {}),
+    preloadQueryWithAuth<string[]>(api.recurring.listRecurringTags, {}),
+    preloadQueryWithAuth<Doc<'oneTimeTransactions'>[]>(api.oneTime.listOneTimeTransactions, {}),
+    preloadQueryWithAuth<string[]>(api.oneTime.listOneTimeTags, {}),
+  ]);
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <TransactionsPageClient
+        initialRecurring={recurringData || []}
+        initialRecurringTags={recurringTags || []}
+        initialOneTime={oneTimeData || []}
+        initialOneTimeTags={oneTimeTags || []}
+      />
+    </div>
+  );
+}

--- a/components/forecast/ForecastControls.tsx
+++ b/components/forecast/ForecastControls.tsx
@@ -29,11 +29,8 @@ export function ForecastControls({
         label="Monthly Income"
       />
       <div className="flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-end">
-        <a href="/recurring" className="text-sm text-blue-500 hover:underline">
-          Manage Recurring Transactions
-        </a>
-        <a href="/one-time" className="text-sm text-blue-500 hover:underline">
-          Manage One Time Transactions
+        <a href="/transactions" className="text-sm text-blue-500 hover:underline">
+          Manage Transactions
         </a>
       </div>
     </div>

--- a/components/forecast/ForecastEmptyState.tsx
+++ b/components/forecast/ForecastEmptyState.tsx
@@ -45,11 +45,8 @@ export function ForecastEmptyState({
           label="Monthly Income"
         />
         <div className="flex flex-col sm:flex-row gap-2 sm:items-center sm:justify-end">
-          <a href="/recurring" className="text-sm text-blue-500 hover:underline">
-            Manage Recurring Transactions
-          </a>
-          <a href="/one-time" className="text-sm text-blue-500 hover:underline">
-            Manage One Time Transactions
+          <a href="/transactions" className="text-sm text-blue-500 hover:underline">
+            Manage Transactions
           </a>
         </div>
       </div>

--- a/components/transactions/TransactionsPageClient.tsx
+++ b/components/transactions/TransactionsPageClient.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useState } from 'react';
+import RecurringPageClient from '@/components/recurring/RecurringPageClient';
+import OneTimePageClient from '@/components/oneTime/OneTimePageClient';
+import { Doc } from '@/convex/_generated/dataModel';
+
+interface Props {
+  initialRecurring: Doc<'recurringTransactions'>[];
+  initialRecurringTags: string[];
+  initialOneTime: Doc<'oneTimeTransactions'>[];
+  initialOneTimeTags: string[];
+}
+
+export default function TransactionsPageClient({
+  initialRecurring,
+  initialRecurringTags,
+  initialOneTime,
+  initialOneTimeTags,
+}: Props) {
+  const [view, setView] = useState<'all' | 'recurring' | 'one-time'>('all');
+
+  const pillClass = (active: boolean) =>
+    `px-3 py-1 rounded-full text-sm cursor-pointer ${active ? 'bg-blue-600 text-white' : 'bg-gray-700 text-gray-300'}`;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex gap-2">
+        <button onClick={() => setView('all')} className={pillClass(view === 'all')}>
+          All
+        </button>
+        <button onClick={() => setView('recurring')} className={pillClass(view === 'recurring')}>
+          Recurring
+        </button>
+        <button onClick={() => setView('one-time')} className={pillClass(view === 'one-time')}>
+          One Time
+        </button>
+      </div>
+      {(view === 'all' || view === 'recurring') && (
+        <RecurringPageClient initialData={initialRecurring} initialTags={initialRecurringTags} />
+      )}
+      {(view === 'all' || view === 'one-time') && (
+        <OneTimePageClient initialData={initialOneTime} initialTags={initialOneTimeTags} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `/transactions` route
- add `TransactionsPageClient` component
- link forecast controls/empty state to new page

## Testing
- `bun test`
