### PR TITLE
Add future one-time transactions to forecast

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { Doc } from "@/convex/_generated/dataModel";
 import { preloadQueryWithAuth } from "@/lib/convex";
 import { preloadForecastData } from "@/components/forecast/ForecastPreload";
 import { ForecastClient } from "@/components/forecast/ForecastClient";
-import { DailyMetric, UserPreferencesData } from "@/components/forecast/types";
+import { DailyMetric, UserPreferencesData, OneTimeTotals } from "@/components/forecast/types";
 
 type Asset = Doc<'assets'>;
 type Debt = Doc<'debts'>;
@@ -42,6 +42,7 @@ export default async function Home() {
           } | null}
           initialPreferences={forecastData.initialPreferences as UserPreferencesData | null}
           initialRecurring={forecastData.initialRecurring as { monthlyIncome: number; monthlyCost: number } | null}
+          initialOneTimeTotals={forecastData.initialOneTimeTotals as { income: number; expense: number } | null}
         />
       </div>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 w-full">

--- a/components/forecast/types.ts
+++ b/components/forecast/types.ts
@@ -63,3 +63,8 @@ export interface RecurringTotals {
   monthlyIncome: number;
   monthlyCost: number;
 }
+
+export interface OneTimeTotals {
+  income: number;
+  expense: number;
+}

--- a/convex/oneTime.ts
+++ b/convex/oneTime.ts
@@ -100,3 +100,24 @@ export const getYearlyTotals = query({
     return { income, expense };
   },
 });
+
+export const getFutureTotals = query({
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return { income: 0, expense: 0 };
+    const now = Date.now();
+    const items = await ctx.db
+      .query("oneTimeTransactions")
+      .withIndex("by_user", (q) => q.eq("userId", userId))
+      .collect();
+    let income = 0;
+    let expense = 0;
+    items.forEach((i) => {
+      if (i.date >= now) {
+        if (i.type === "income") income += i.amount;
+        else expense += i.amount;
+      }
+    });
+    return { income, expense };
+  },
+});


### PR DESCRIPTION
## Summary
- incorporate future one-time transactions into forecast calculations
- preload future one-time totals on the server
- use future one-time totals in ForecastClient monthly net calculation

## Testing
- `npm test`