### PR TITLE
Fix chart label overflow

### DIFF
--- a/__tests__/formatCompactCurrency.test.ts
+++ b/__tests__/formatCompactCurrency.test.ts
@@ -1,0 +1,6 @@
+import { test, expect } from 'bun:test';
+import { formatCompactCurrency } from '../lib/formatters';
+
+test('formats large values with compact notation', () => {
+  expect(formatCompactCurrency(1250000)).toBe('$1.3M');
+});

--- a/components/net-worth-chart.tsx
+++ b/components/net-worth-chart.tsx
@@ -14,7 +14,7 @@ import {
 } from 'recharts';
 
 import { Doc } from "@/convex/_generated/dataModel";
-import { formatCurrency } from '@/lib/formatters';
+import { formatCurrency, formatCompactCurrency } from '@/lib/formatters';
 
 type DailyMetric = Doc<'dailyMetrics'> & {
   isProjected?: boolean;
@@ -242,7 +242,7 @@ export default function NetWorthChart({ metrics, showUncertainty = true }: NetWo
           />
           <YAxis
             domain={yAxisDomain}
-            tickFormatter={(value) => formatCurrency(value)}
+            tickFormatter={(value) => formatCompactCurrency(value)}
             tickCount={8} // Suggest number of ticks
           />
           <Tooltip 

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -36,3 +36,16 @@ export function formatNumber(num: number): string {
 export function formatCurrency(amount: number, currency: string = 'USD'): string {
   return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount);
 }
+
+/**
+ * Format a currency value using compact notation for large amounts
+ * e.g. $1.2M instead of $1,200,000
+ */
+export function formatCompactCurrency(amount: number, currency: string = 'USD'): string {
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    notation: 'compact',
+    compactDisplay: 'short'
+  }).format(amount);
+}


### PR DESCRIPTION
## Summary
- show forecast chart y-axis labels using compact currency notation
- support formatting for compact currencies
- test new format helper

## Testing
- `bun test`
