### PR TITLE
Improve summary table placement

### DIFF
--- a/components/transactions/TransactionsPageClient.tsx
+++ b/components/transactions/TransactionsPageClient.tsx
@@ -212,6 +212,39 @@ export default function TransactionsPageClient({
         <button onClick={() => setView('one-time')} className={pillClass(view === 'one-time')}>One Time</button>
         <button onClick={() => setView('future')} className={pillClass(view === 'future')}>Future</button>
       </div>
+      <div className="overflow-x-auto self-end">
+        <table className="text-sm mt-2">
+          <thead>
+            <tr>
+              <th className="px-2 py-1" />
+              <th className="px-2 py-1">Monthly</th>
+              <th className="px-2 py-1">Annual</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td className="px-2 py-1">Income</td>
+              <td className="px-2 py-1 text-green-500">{formatCurrency(monthlyTotals.income)}</td>
+              <td className="px-2 py-1 text-green-500">{formatCurrency(annualTotals.income)}</td>
+            </tr>
+            <tr>
+              <td className="px-2 py-1">Cost</td>
+              <td className="px-2 py-1 text-red-500">{formatCurrency(monthlyTotals.expense)}</td>
+              <td className="px-2 py-1 text-red-500">{formatCurrency(annualTotals.expense)}</td>
+            </tr>
+            <tr>
+              <td className="px-2 py-1 font-semibold">Net</td>
+              <td className={`px-2 py-1 ${monthlyTotals.income - monthlyTotals.expense >= 0 ? 'text-green-500' : 'text-red-500'}`}>{formatCurrency(monthlyTotals.income - monthlyTotals.expense)}</td>
+              <td className={`px-2 py-1 ${annualTotals.income - annualTotals.expense >= 0 ? 'text-green-500' : 'text-red-500'}`}>{formatCurrency(annualTotals.income - annualTotals.expense)}</td>
+            </tr>
+          </tbody>
+        </table>
+        {futureAnnualTotals.expense > 0 && (
+          <div className="text-sm mt-1">
+            Future One-Time Cost: <span className="text-red-500">{formatCurrency(futureAnnualTotals.expense)}</span>
+          </div>
+        )}
+      </div>
       {/* Mobile card list */}
       <div className="md:hidden space-y-3">
         {combined.map((t) => (
@@ -382,31 +415,6 @@ export default function TransactionsPageClient({
             ))}
           </tbody>
         </table>
-        <div className="flex flex-col items-end gap-1 text-sm mt-2">
-          <div>
-            Monthly Income: <span className="text-green-500">{formatCurrency(monthlyTotals.income)}</span>
-          </div>
-          <div>
-            Monthly Expenses: <span className="text-red-500">{formatCurrency(monthlyTotals.expense)}</span>
-          </div>
-          <div>
-            Monthly Net: <span className={monthlyTotals.income - monthlyTotals.expense >= 0 ? 'text-green-500' : 'text-red-500'}>{formatCurrency(monthlyTotals.income - monthlyTotals.expense)}</span>
-          </div>
-          <div>
-            Annual Income: <span className="text-green-500">{formatCurrency(annualTotals.income)}</span>
-          </div>
-          <div>
-            Annual Expenses: <span className="text-red-500">{formatCurrency(annualTotals.expense)}</span>
-          </div>
-          <div>
-            Annual Net: <span className={annualTotals.income - annualTotals.expense >= 0 ? 'text-green-500' : 'text-red-500'}>{formatCurrency(annualTotals.income - annualTotals.expense)}</span>
-          </div>
-          {futureAnnualTotals.expense > 0 && (
-            <div>
-              Future One-Time Cost: <span className="text-red-500">{formatCurrency(futureAnnualTotals.expense)}</span>
-            </div>
-          )}
-        </div>
       </div>
       <button
         onClick={() => {


### PR DESCRIPTION
## Summary
- move monthly/annual summary numbers above transactions list
- use a table layout with income, cost and net rows

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for eslint setup)*