### PR TITLE
Add transactions link and remove card

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import { Doc } from "@/convex/_generated/dataModel";
 import { preloadQueryWithAuth } from "@/lib/convex";
 import { preloadForecastData } from "@/components/forecast/ForecastPreload";
 import { ForecastClient } from "@/components/forecast/ForecastClient";
-import { DailyMetric, UserPreferencesData, OneTimeTotals } from "@/components/forecast/types";
+import { DailyMetric, UserPreferencesData } from "@/components/forecast/types";
 
 type Asset = Doc<'assets'>;
 type Debt = Doc<'debts'>;
@@ -11,19 +11,14 @@ type Wallet = Doc<'wallets'>;
 
 import AssetsCard from "@/components/cards/assets-card";
 import DebtsCard from "@/components/cards/debts-card";
-import OneTimeCard from "@/components/cards/one-time-card";
 
 export default async function Home() {
   // Preload all data with authentication
-  const [forecastData, assetsPreload, debtsPreload, walletsPreload, oneTimePreload] = await Promise.all([
+  const [forecastData, assetsPreload, debtsPreload, walletsPreload] = await Promise.all([
     preloadForecastData(),
     preloadQueryWithAuth<Asset[]>(api.assets.listAssets, {}),
     preloadQueryWithAuth<Debt[]>(api.debts.listDebts, {}),
-    preloadQueryWithAuth<Wallet[]>(api.wallets.listWallets, {}),
-    preloadQueryWithAuth<Doc<'oneTimeTransactions'>[]>(
-      api.oneTime.listOneTimeTransactions,
-      {},
-    )
+    preloadQueryWithAuth<Wallet[]>(api.wallets.listWallets, {})
   ]);
 
   return (
@@ -44,10 +39,13 @@ export default async function Home() {
           initialOneTimeTotals={forecastData.initialOneTimeTotals as { income: number; expense: number } | null}
         />
       </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 w-full">
-          <AssetsCard assets={assetsPreload || []} wallets={walletsPreload || []} />
-          <DebtsCard debts={debtsPreload || []} />
-          <OneTimeCard items={oneTimePreload || []} />
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 w-full">
+          <div className="lg:col-span-2">
+            <AssetsCard assets={assetsPreload || []} wallets={walletsPreload || []} />
+          </div>
+          <div className="lg:col-span-2">
+            <DebtsCard debts={debtsPreload || []} />
+          </div>
         </div>
       </div>
     </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { UserButton } from '@clerk/nextjs';
-import { BeakerIcon, CurrencyDollarIcon } from '@heroicons/react/24/outline';
+import { BeakerIcon, CurrencyDollarIcon, BanknotesIcon } from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
 
 export default function Header() {
@@ -22,6 +22,10 @@ export default function Header() {
                 <Link href="/quotes" className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1">
                   <CurrencyDollarIcon className="w-4 h-4" />
                   <span>Quotes</span>
+                </Link>
+                <Link href="/transactions" className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1">
+                  <BanknotesIcon className="w-4 h-4" />
+                  <span>Transactions</span>
                 </Link>
               </nav>
             </div>


### PR DESCRIPTION
## Summary
- link to transactions from the main navigation bar
- simplify dashboard to only show assets and debts
- expand assets and debts cards to span two columns on large screens

## Testing
- `npm test`
