### PR TITLE
Add monthly cost breakdown pie chart

### DIFF
--- a/__tests__/costBreakdown.test.ts
+++ b/__tests__/costBreakdown.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from 'bun:test';
+import { getMonthlyCostBreakdown } from '../lib/costs';
+
+const recurring = [
+  { frequency: 'monthly', amount: 1000, type: 'expense', tags: ['rent'] },
+  { frequency: 'yearly', amount: 240, type: 'expense', tags: ['insurance'] },
+  { frequency: 'monthly', amount: 200, type: 'expense' }
+];
+
+const oneTime = [
+  { amount: 1200, type: 'expense', tags: ['vacation'] }
+];
+
+test('aggregates monthly cost by tag', () => {
+  const result = getMonthlyCostBreakdown(recurring, oneTime);
+  expect(result.find(r => r.tag === 'rent')!.amount).toBe(1000);
+  expect(result.find(r => r.tag === 'insurance')!.amount).toBe(20);
+  expect(result.find(r => r.tag === 'vacation')!.amount).toBe(100);
+  expect(result.find(r => r.tag === 'Other')!.amount).toBe(200);
+});

--- a/app/costs/page.tsx
+++ b/app/costs/page.tsx
@@ -1,0 +1,18 @@
+import { api } from '@/convex/_generated/api';
+import { preloadQueryWithAuth } from '@/lib/convex';
+import MonthlyCostPieChart from '@/components/costs/MonthlyCostPieChart';
+
+export default async function CostsPage() {
+  const data = await preloadQueryWithAuth<{ tag: string; amount: number }[]>(
+    api.costs.monthlyCostBreakdown,
+    {}
+  );
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-2xl font-bold mb-4">Monthly Cost Breakdown</h1>
+      <div className="w-full">
+        <MonthlyCostPieChart data={data || []} />
+      </div>
+    </div>
+  );
+}

--- a/components/costs/MonthlyCostPieChart.tsx
+++ b/components/costs/MonthlyCostPieChart.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import { formatCurrency } from '@/lib/formatters';
+
+interface CostData { tag: string; amount: number }
+
+interface Props { data: CostData[] }
+
+export default function MonthlyCostPieChart({ data }: Props) {
+  if (!data || data.length === 0) {
+    return <p className="text-gray-400 text-center">No expense data.</p>;
+  }
+  const COLORS = ['#f87171','#fb923c','#fbbf24','#34d399','#60a5fa','#a78bfa','#f472b6','#facc15'];
+  const chartData = data.map(d => ({ name: d.tag, value: d.amount }));
+  return (
+    <ResponsiveContainer width="100%" height={400}>
+      <PieChart>
+        <Pie data={chartData} dataKey="value" nameKey="name" outerRadius={120} label={({name, percent}) => `${name}: ${(percent*100).toFixed(0)}%`}>
+          {chartData.map((_, idx) => (
+            <Cell key={idx} fill={COLORS[idx % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip formatter={(v) => formatCurrency(v as number)} />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as holdingsNode from "../holdingsNode.js";
 import type * as metrics from "../metrics.js";
 import type * as quoteActions from "../quoteActions.js";
 import type * as quotes from "../quotes.js";
+import type * as costs from "../costs.js";
 import type * as oneTime from "../oneTime.js";
 import type * as recurring from "../recurring.js";
 import type * as simulations from "../simulations.js";
@@ -45,6 +46,7 @@ declare const fullApi: ApiFromModules<{
   metrics: typeof metrics;
   quoteActions: typeof quoteActions;
   quotes: typeof quotes;
+  costs: typeof costs;
   oneTime: typeof oneTime;
   recurring: typeof recurring;
   simulations: typeof simulations;

--- a/convex/costs.ts
+++ b/convex/costs.ts
@@ -1,0 +1,43 @@
+import { query } from './_generated/server';
+import { getUserId } from './users';
+import { monthlyAmount } from './recurring';
+
+export const monthlyCostBreakdown = query({
+  handler: async (ctx) => {
+    const userId = await getUserId(ctx);
+    if (!userId) return [] as { tag: string; amount: number }[];
+
+    const recurring = await ctx.db
+      .query('recurringTransactions')
+      .withIndex('by_user', q => q.eq('userId', userId))
+      .collect();
+
+    const oneTime = await ctx.db
+      .query('oneTimeTransactions')
+      .withIndex('by_user', q => q.eq('userId', userId))
+      .collect();
+
+    const totals = new Map<string, number>();
+    const add = (tag: string, amt: number) => {
+      totals.set(tag, (totals.get(tag) ?? 0) + amt);
+    };
+
+    recurring.forEach(r => {
+      if (r.type !== 'expense') return;
+      const amt = monthlyAmount(r);
+      if (r.tags && r.tags.length > 0) r.tags.forEach(tag => add(tag, amt));
+      else add('Other', amt);
+    });
+
+    oneTime.forEach(o => {
+      if (o.type !== 'expense') return;
+      const amt = o.amount / 12;
+      if (o.tags && o.tags.length > 0) o.tags.forEach(tag => add(tag, amt));
+      else add('Other', amt);
+    });
+
+    return Array.from(totals.entries())
+      .map(([tag, amount]) => ({ tag, amount }))
+      .sort((a, b) => b.amount - a.amount);
+  }
+});

--- a/lib/costs.ts
+++ b/lib/costs.ts
@@ -1,0 +1,55 @@
+import { monthlyAmount } from './recurring';
+import { monthlyOneTimeAmount } from './oneTime';
+
+export interface RecurringTransaction {
+  amount: number;
+  type: 'income' | 'expense';
+  frequency: 'monthly' | 'yearly' | 'weekly' | 'quarterly';
+  daysOfMonth?: number[] | null;
+  daysOfWeek?: number[] | null;
+  tags?: string[] | null;
+}
+
+export interface OneTimeTransaction {
+  amount: number;
+  type: 'income' | 'expense';
+  tags?: string[] | null;
+}
+
+export interface CostBreakdownItem {
+  tag: string;
+  amount: number;
+}
+
+export function getMonthlyCostBreakdown(
+  recurring: RecurringTransaction[],
+  oneTime: OneTimeTransaction[]
+): CostBreakdownItem[] {
+  const totals = new Map<string, number>();
+
+  const add = (tag: string, amt: number) => {
+    totals.set(tag, (totals.get(tag) ?? 0) + amt);
+  };
+
+  recurring.forEach((r) => {
+    if (r.type !== 'expense') return;
+    const amt = monthlyAmount(r);
+    if (r.tags && r.tags.length > 0) {
+      r.tags.forEach((tag) => add(tag, amt));
+    } else {
+      add('Other', amt);
+    }
+  });
+
+  oneTime.forEach((o) => {
+    if (o.type !== 'expense') return;
+    const amt = monthlyOneTimeAmount(o.amount);
+    if (o.tags && o.tags.length > 0) {
+      o.tags.forEach((tag) => add(tag, amt));
+    } else {
+      add('Other', amt);
+    }
+  });
+
+  return Array.from(totals.entries()).map(([tag, amount]) => ({ tag, amount }));
+}


### PR DESCRIPTION
## Summary
- show monthly cost breakdown by tag
- compute monthly cost totals across recurring and one-time transactions
- add pie chart component and a new `/costs` page
- include helper and tests

## Testing
- `npm test`