### PR TITLE
Add dev auth bypass flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment variables
+NEXT_PUBLIC_CONVEX_URL=
+CLERK_URI=
+FINNHUB_API_KEY=
+MORALIS_API_KEY=
+# Bypass authentication in local development
+BYPASS_AUTH=false
+NEXT_PUBLIC_BYPASS_AUTH=false
+BYPASS_AUTH_EMAIL=rtcx86@gmail.com

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+### Skipping authentication locally
+
+Set `BYPASS_AUTH=true` and `NEXT_PUBLIC_BYPASS_AUTH=true` in your `.env` file to bypass Clerk when developing. The app will assume a signed in user with the email from `BYPASS_AUTH_EMAIL`.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/app/ConvexProvider.tsx
+++ b/app/ConvexProvider.tsx
@@ -4,6 +4,7 @@ import { ReactNode } from "react";
 import { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { useAuth } from "@clerk/nextjs";
+
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export default function ConvexClientProvider({
@@ -11,8 +12,21 @@ export default function ConvexClientProvider({
 }: {
   children: ReactNode;
 }) {
+  const auth = useAuth();
+
+  // Provide a mock auth object when bypassing Clerk in development
+  const mockAuth = {
+    isLoaded: true,
+    isSignedIn: true,
+    userId: "dev-user",
+    getToken: async () => "dev-token",
+  };
+
+  const authState =
+    process.env.NEXT_PUBLIC_BYPASS_AUTH === "true" ? mockAuth : auth;
+
   return (
-    <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
+    <ConvexProviderWithClerk client={convex} useAuth={() => authState}>
       {children}
     </ConvexProviderWithClerk>
   );

--- a/app/auth.ts
+++ b/app/auth.ts
@@ -1,6 +1,16 @@
 import { auth } from "@clerk/nextjs/server";
 
+/**
+ * Retrieve the Convex auth token.
+ *
+ * When BYPASS_AUTH is enabled this returns a stub token so
+ * backend calls can be made without Clerk in local development.
+ */
 export async function getAuthToken() {
+  if (process.env.BYPASS_AUTH === "true") {
+    return "dev-token";
+  }
+
   const authInfo = await auth();
   return authInfo.getToken({ template: "convex" }) ?? undefined;
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,9 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 const isPublicRoute = createRouteMatcher(['/sign-in(.*)'])
 
 export default clerkMiddleware(async (auth, request) => {
+  if (process.env.BYPASS_AUTH === 'true' && !isPublicRoute(request)) {
+    return
+  }
   if (!isPublicRoute(request)) {
     await auth.protect()
   }


### PR DESCRIPTION
## Summary
- add an example environment file with bypass variables
- allow `.env.example` to be committed
- bypass Clerk in middleware, on the server, and in the Convex provider
- document how to skip auth in the README

## Testing
- `bun test`