### PR TITLE
Persist one-time transaction hidden state

### DIFF
--- a/__tests__/costBreakdown.test.ts
+++ b/__tests__/costBreakdown.test.ts
@@ -9,7 +9,7 @@ const recurring = [
 
 const oneTime = [
   { name: 'Vacation', amount: 1200, type: 'expense' },
-  { name: 'Treat', amount: 60, type: 'expense' }
+  { name: 'Treat', amount: 60, type: 'expense', hidden: true }
 ];
 
 test('aggregates monthly cost by name and groups small ones', () => {
@@ -18,5 +18,5 @@ test('aggregates monthly cost by name and groups small ones', () => {
   expect(result.find(r => r.label === 'Coffee')!.amount).toBe(200);
   expect(result.find(r => r.label === 'Vacation')!.amount).toBe(100);
   expect(result.find(r => r.label === 'Insurance')!.amount).toBe(20);
-  expect(result.find(r => r.label === 'Other')!.amount).toBeCloseTo(5);
+  expect(result.find(r => r.label === 'Other')).toBeUndefined();
 });

--- a/components/cards/one-time-card.tsx
+++ b/components/cards/one-time-card.tsx
@@ -23,14 +23,19 @@ export default function OneTimeCard({ items: initialItems }: OneTimeCardProps) {
   const total = useMemo(() => {
     if (!items) return 0;
     return items
-      .filter((i) => new Date(i.date).getFullYear() === currentYear && i.type === 'expense')
+      .filter(
+        (i) =>
+          !i.hidden &&
+          new Date(i.date).getFullYear() === currentYear &&
+          i.type === 'expense'
+      )
       .reduce((sum, t) => sum + t.amount, 0);
   }, [items, currentYear]);
 
   const sorted = useMemo(() => {
     if (!items) return [];
     return [...items]
-      .filter((i) => new Date(i.date).getFullYear() === currentYear)
+      .filter((i) => new Date(i.date).getFullYear() === currentYear && !i.hidden)
       .sort((a, b) => b.date - a.date)
       .slice(0, 5);
   }, [items, currentYear]);

--- a/components/oneTime/OneTimePageClient.tsx
+++ b/components/oneTime/OneTimePageClient.tsx
@@ -33,6 +33,10 @@ export default function OneTimePageClient({ initialData, initialTags }: OneTimeP
     return data.filter((t) => tags.every((tag) => t.tags?.includes(tag)));
   }, [data, tagFilter]);
 
+  const visibleData = useMemo(() => {
+    return filteredData.filter((t) => !t.hidden);
+  }, [filteredData]);
+
   const sortedData = useMemo(() => {
     const arr = [...filteredData];
     if (sortField === 'amount') {
@@ -52,7 +56,7 @@ export default function OneTimePageClient({ initialData, initialTags }: OneTimeP
   }, [filteredData, sortField, sortDir]);
 
   const totals = useMemo(() => {
-    const result = filteredData.reduce(
+    const result = visibleData.reduce(
       (acc, t) => {
         if (t.type === 'income') acc.income += t.amount;
         else acc.expense += t.amount;
@@ -64,7 +68,7 @@ export default function OneTimePageClient({ initialData, initialTags }: OneTimeP
       ...result,
       net: result.income - result.expense,
     };
-  }, [filteredData]);
+  }, [visibleData]);
 
   const toggleSort = (field: 'amount' | 'date' | 'type') => {
     if (sortField === field) {

--- a/convex/costs.ts
+++ b/convex/costs.ts
@@ -29,6 +29,7 @@ export const monthlyCostBreakdown = query({
     });
 
     oneTime.forEach(o => {
+      if (o.hidden) return;
       if (o.type !== 'expense') return;
       const amt = o.amount / 12;
       add(o.name, amt);

--- a/convex/oneTime.ts
+++ b/convex/oneTime.ts
@@ -20,6 +20,7 @@ export const addOneTimeTransaction = mutation({
     type: v.union(v.literal("income"), v.literal("expense")),
     date: v.number(),
     tags: v.optional(v.array(v.string())),
+    hidden: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
@@ -36,6 +37,7 @@ export const updateOneTimeTransaction = mutation({
     type: v.optional(v.union(v.literal("income"), v.literal("expense"))),
     date: v.optional(v.number()),
     tags: v.optional(v.array(v.string())),
+    hidden: v.optional(v.boolean()),
   },
   handler: async (ctx, { id, ...updates }) => {
     const userId = await getUserId(ctx);
@@ -92,6 +94,7 @@ export const getYearlyTotals = query({
     let income = 0;
     let expense = 0;
     items.forEach((i) => {
+      if (i.hidden) return;
       if (i.date >= start && i.date < end) {
         if (i.type === "income") income += i.amount;
         else expense += i.amount;
@@ -113,6 +116,7 @@ export const getFutureTotals = query({
     let income = 0;
     let expense = 0;
     items.forEach((i) => {
+      if (i.hidden) return;
       if (i.date >= now) {
         if (i.type === "income") income += i.amount;
         else expense += i.amount;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -160,6 +160,7 @@ export default defineSchema({
     type: v.union(v.literal("income"), v.literal("expense")),
     date: v.number(), // Unix timestamp
     tags: v.optional(v.array(v.string())),
+    hidden: v.optional(v.boolean()),
   }).index("by_user", ["userId"]),
 
   // Store simulation adjustments and results

--- a/lib/costs.ts
+++ b/lib/costs.ts
@@ -14,6 +14,7 @@ export interface OneTimeTransaction {
   amount: number;
   type: 'income' | 'expense';
   name: string;
+  hidden?: boolean;
 }
 
 export interface CostBreakdownItem {
@@ -38,6 +39,7 @@ export function getMonthlyCostBreakdown(
   });
 
   oneTime.forEach((o) => {
+    if (o.hidden) return;
     if (o.type !== 'expense') return;
     const amt = monthlyOneTimeAmount(o.amount);
     add(o.name, amt);


### PR DESCRIPTION
## Summary
- allow setting one-time transactions as hidden
- ignore hidden one-time transactions when calculating totals
- update cards and pages to exclude hidden entries from totals
- persist hide/show toggle for one-time items in Transactions page
- adjust cost breakdown logic and tests

## Testing
- `bun test`