### PR TITLE
Add Convex auth bypass

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment variables
+NEXT_PUBLIC_CONVEX_URL=
+CLERK_URI=
+FINNHUB_API_KEY=
+MORALIS_API_KEY=
+# Bypass authentication in local development
+BYPASS_AUTH=false
+NEXT_PUBLIC_BYPASS_AUTH=false
+BYPASS_AUTH_EMAIL=rtcx86@gmail.com

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+### Skipping authentication locally
+
+Set `BYPASS_AUTH=true` and `NEXT_PUBLIC_BYPASS_AUTH=true` in your `.env` file to bypass Clerk when developing. The app will assume a signed in user with the email from `BYPASS_AUTH_EMAIL`.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/app/ConvexProvider.tsx
+++ b/app/ConvexProvider.tsx
@@ -4,6 +4,8 @@ import { ReactNode } from "react";
 import { ConvexReactClient } from "convex/react";
 import { ConvexProviderWithClerk } from "convex/react-clerk";
 import { useAuth } from "@clerk/nextjs";
+import type { UseAuthReturn } from "@clerk/types";
+
 const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
 
 export default function ConvexClientProvider({
@@ -11,8 +13,28 @@ export default function ConvexClientProvider({
 }: {
   children: ReactNode;
 }) {
+  const auth = useAuth();
+
+  // Provide a mock auth object when bypassing Clerk in development
+  const mockAuth = {
+    isLoaded: true,
+    isSignedIn: true,
+    userId: "dev-user",
+    sessionId: "dev-session",
+    actor: null,
+    orgId: null,
+    orgRole: null,
+    orgSlug: null,
+    signOut: async () => {},
+    has: () => false,
+    getToken: async () => "dev-token",
+  } as UseAuthReturn;
+
+  const authState =
+    process.env.NEXT_PUBLIC_BYPASS_AUTH === "true" ? mockAuth : auth;
+
   return (
-    <ConvexProviderWithClerk client={convex} useAuth={useAuth}>
+    <ConvexProviderWithClerk client={convex} useAuth={() => authState}>
       {children}
     </ConvexProviderWithClerk>
   );

--- a/app/auth.ts
+++ b/app/auth.ts
@@ -1,6 +1,16 @@
 import { auth } from "@clerk/nextjs/server";
 
+/**
+ * Retrieve the Convex auth token.
+ *
+ * When BYPASS_AUTH is enabled this returns a stub token so
+ * backend calls can be made without Clerk in local development.
+ */
 export async function getAuthToken() {
+  if (process.env.BYPASS_AUTH === "true") {
+    return "dev-token";
+  }
+
   const authInfo = await auth();
   return authInfo.getToken({ template: "convex" }) ?? undefined;
 }

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -1,11 +1,12 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
 import { Id } from "./_generated/dataModel";
+import { getUserIdentity } from "./users";
 
 // Asset queries
 export const listAssets = query({
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     if (userId) {
@@ -29,7 +30,7 @@ export const getAssetsByType = query({
     type: v.union(v.literal("real_estate"), v.literal("stocks"), v.literal("crypto"), v.literal("cash"), v.literal("other"))
   },
   handler: async (ctx, { type }) => {
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     if (userId) {
@@ -51,7 +52,7 @@ export const getAssetsByType = query({
 
 export const getAssetsTotal = query({
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     let assets;
@@ -85,7 +86,7 @@ export const getAsset = query({
     }
     
     // If the asset has a userId, verify the current user has access
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     if (asset.userId && asset.userId !== userId) {
@@ -115,7 +116,7 @@ export const addAsset = mutation({
   },
   handler: async (ctx, args) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Add the asset with the user ID
@@ -144,7 +145,7 @@ export const updateAsset = mutation({
   },
   handler: async (ctx, { id, ...updates }) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Get the asset
@@ -169,7 +170,7 @@ export const deleteAsset = mutation({
   },
   handler: async (ctx, { id }) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Get the asset

--- a/convex/debts.ts
+++ b/convex/debts.ts
@@ -1,10 +1,11 @@
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
+import { getUserIdentity } from "./users";
 
 // Debt queries
 export const listDebts = query({
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     if (userId) {
@@ -34,7 +35,7 @@ export const getDebt = query({
     }
     
     // If the debt has a userId, verify the current user has access
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     if (debt.userId && debt.userId !== userId) {
@@ -51,7 +52,7 @@ export const getDebtsByType = query({
     type: v.union(v.literal("mortgage"), v.literal("loan"), v.literal("credit_card"), v.literal("crypto"), v.literal("other"))
   },
   handler: async (ctx, { type }) => {
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     if (userId) {
@@ -73,7 +74,7 @@ export const getDebtsByType = query({
 
 export const getDebtsTotal = query({
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     let debts;
@@ -116,7 +117,7 @@ export const addDebt = mutation({
   },
   handler: async (ctx, args) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Add the debt with the user ID
@@ -147,7 +148,7 @@ export const updateDebt = mutation({
   },
   handler: async (ctx, { id, ...updates }) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Get the debt
@@ -170,7 +171,7 @@ export const deleteDebt = mutation({
   args: { id: v.id("debts") },
   handler: async (ctx, args) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Get the debt

--- a/convex/holdings.ts
+++ b/convex/holdings.ts
@@ -3,6 +3,7 @@ import { query, mutation, QueryCtx } from "./_generated/server";
 import { Id, Doc } from "./_generated/dataModel";
 import { api } from "./_generated/api";
 import { getQuotesHelper } from "./quotes";
+import { getUserIdentity } from "./users";
 
 type Wallet = Doc<"wallets">;
 type Holding = Doc<"holdings">;
@@ -276,7 +277,7 @@ export const upsertHolding = mutation({
     },
     handler: async (ctx, { walletId, symbol, quantity, chain, ignore, quoteSymbol, isDebt, quoteType }) => {
       // Get the user ID from authentication
-      const identity = await ctx.auth.getUserIdentity();
+      const identity = await getUserIdentity(ctx);
       const authUserId = identity?.subject;
       
       // Check if wallet exists
@@ -373,7 +374,7 @@ export const addHolding = mutation({
   },
   handler: async (ctx, args) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Get the wallet to check if the user has access
@@ -429,7 +430,7 @@ export const updateHolding = mutation({
   },
   handler: async (ctx, { id, ...updates }) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Get the holding
@@ -463,7 +464,7 @@ export const deleteHolding = mutation({
   },
   handler: async (ctx, { id }) => {
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Get the holding
@@ -496,7 +497,7 @@ export const toggleHoldingIgnore = mutation({
     }
     
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Get the wallet to check ownership

--- a/convex/metrics.ts
+++ b/convex/metrics.ts
@@ -2,13 +2,14 @@ import { query, mutation, QueryCtx } from "./_generated/server";
 import { Doc, Id } from "./_generated/dataModel";
 import { getQuotesHelper } from "./quotes";
 import { updateAllWalletValuesHelper } from "./wallets";
+import { getUserIdentity } from "./users";
 
 type DailyMetric = Doc<"dailyMetrics">;
 
 // Query to get historical metrics
 export const getDailyMetrics = query({
     handler: async (ctx): Promise<DailyMetric[]> => {
-        const identity = await ctx.auth.getUserIdentity();
+        const identity = await getUserIdentity(ctx);
         const userId = identity?.subject;
 
         if (userId) {
@@ -204,7 +205,7 @@ export async function getCurrentNetWorthHelper(ctx: QueryCtx, userId: string) {
 export const getCurrentNetWorth = query({
     handler: async (ctx) => {
         // Get the user ID from authentication or use the override
-        const identity = await ctx.auth.getUserIdentity();
+        const identity = await getUserIdentity(ctx);
         const authUserId = identity?.subject;
 
         if (!authUserId) {

--- a/convex/wallets.ts
+++ b/convex/wallets.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { DatabaseReader, mutation, query, MutationCtx } from "./_generated/server";
 import { Id } from "./_generated/dataModel";
 import { getHoldingsValueHelper } from "./holdings";
+import { getUserIdentity } from "./users";
 
 // Get a wallet by address
 export const getWalletByAddress = query({
@@ -10,7 +11,7 @@ export const getWalletByAddress = query({
     },
     handler: async (ctx, { address }) => {
         // Get the user ID from authentication
-        const identity = await ctx.auth.getUserIdentity();
+        const identity = await getUserIdentity(ctx);
         const userId = identity?.subject;
         
         // Find the wallet by address
@@ -42,7 +43,7 @@ async function updateWalletValueHelper(ctx: MutationCtx, walletId: Id<"wallets">
     // Check authentication if not skipped
     if (!options?.skipAuth) {
         // Get the user ID from authentication
-        const identity = await ctx.auth.getUserIdentity();
+        const identity = await getUserIdentity(ctx);
         const userId = identity?.subject;
         
         console.log("User ID from auth:", userId);
@@ -116,7 +117,7 @@ export const addWallet = mutation({
     },
     handler: async (ctx, { name, address, chainType }) => {
         // Get the user ID from authentication
-        const identity = await ctx.auth.getUserIdentity();
+        const identity = await getUserIdentity(ctx);
         const userId = identity?.subject;
         
         // Validate address format based on chain type
@@ -172,7 +173,7 @@ export async function updateWalletHelper(ctx: MutationCtx, args: {
     }
     
     // Get the user ID from authentication
-    const identity = await ctx.auth.getUserIdentity();
+    const identity = await getUserIdentity(ctx);
     const userId = identity?.subject;
     
     // Check if the user has access to this wallet
@@ -206,7 +207,7 @@ export const deleteWallet = mutation({
     },
     handler: async (ctx, { id }) => {
         // Get the user ID from authentication
-        const identity = await ctx.auth.getUserIdentity();
+        const identity = await getUserIdentity(ctx);
         const userId = identity?.subject;
         
         // Get the wallet
@@ -240,7 +241,7 @@ export const deleteWallet = mutation({
 // Helper function to list wallets
 export async function listWalletsHelper(ctx: { db: DatabaseReader, auth?: { getUserIdentity: () => Promise<any> } }) {
     // Get the user ID from authentication if available
-    const identity = ctx.auth ? await ctx.auth.getUserIdentity() : null;
+    const identity = ctx.auth ? await getUserIdentity(ctx as any) : null;
     const userId = identity?.subject;
     
     if (userId) {
@@ -279,7 +280,7 @@ export const getWallet = query({
         }
         
         // If the wallet has a userId, verify the current user has access
-        const identity = await ctx.auth.getUserIdentity();
+        const identity = await getUserIdentity(ctx);
         const userId = identity?.subject;
         
         if (wallet.userId && wallet.userId !== userId) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,6 +3,9 @@ import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 const isPublicRoute = createRouteMatcher(['/sign-in(.*)'])
 
 export default clerkMiddleware(async (auth, request) => {
+  if (process.env.BYPASS_AUTH === 'true' && !isPublicRoute(request)) {
+    return
+  }
   if (!isPublicRoute(request)) {
     await auth.protect()
   }


### PR DESCRIPTION
## Summary
- stub Clerk auth with required fields in `ConvexProvider`
- centralize fake identity generation in `convex/users`
- bypass auth in Convex functions when enabled

## Testing
- `bun test`
- `npm run build`