### PR TITLE
Persist one-time transaction hidden state

### DIFF
--- a/__tests__/costBreakdown.test.ts
+++ b/__tests__/costBreakdown.test.ts
@@ -9,7 +9,7 @@ const recurring = [
 
 const oneTime = [
   { name: 'Vacation', amount: 1200, type: 'expense' },
-  { name: 'Treat', amount: 60, type: 'expense' }
+  { name: 'Treat', amount: 60, type: 'expense', hidden: true }
 ];
 
 test('aggregates monthly cost by name and groups small ones', () => {
@@ -18,5 +18,5 @@ test('aggregates monthly cost by name and groups small ones', () => {
   expect(result.find(r => r.label === 'Coffee')!.amount).toBe(200);
   expect(result.find(r => r.label === 'Vacation')!.amount).toBe(100);
   expect(result.find(r => r.label === 'Insurance')!.amount).toBe(20);
-  expect(result.find(r => r.label === 'Other')!.amount).toBeCloseTo(5);
+  expect(result.find(r => r.label === 'Other')).toBeUndefined();
 });

--- a/components/cards/one-time-card.tsx
+++ b/components/cards/one-time-card.tsx
@@ -23,14 +23,19 @@ export default function OneTimeCard({ items: initialItems }: OneTimeCardProps) {
   const total = useMemo(() => {
     if (!items) return 0;
     return items
-      .filter((i) => new Date(i.date).getFullYear() === currentYear && i.type === 'expense')
+      .filter(
+        (i) =>
+          !i.hidden &&
+          new Date(i.date).getFullYear() === currentYear &&
+          i.type === 'expense'
+      )
       .reduce((sum, t) => sum + t.amount, 0);
   }, [items, currentYear]);
 
   const sorted = useMemo(() => {
     if (!items) return [];
     return [...items]
-      .filter((i) => new Date(i.date).getFullYear() === currentYear)
+      .filter((i) => new Date(i.date).getFullYear() === currentYear && !i.hidden)
       .sort((a, b) => b.date - a.date)
       .slice(0, 5);
   }, [items, currentYear]);

--- a/components/oneTime/transaction-form.tsx
+++ b/components/oneTime/transaction-form.tsx
@@ -18,6 +18,7 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
     transaction?.date ? new Date(transaction.date).toISOString().slice(0, 10) : ''
   );
   const [tags, setTags] = useState(transaction?.tags ? transaction.tags.join(',') : '');
+  const [hidden, setHidden] = useState(transaction?.hidden || false);
 
   const existingTags = useQuery(api.oneTime.listOneTimeTags) ?? [];
 
@@ -31,6 +32,7 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
       amount: Number(amount),
       type,
       date: date ? new Date(date).getTime() : Date.now(),
+      hidden,
     };
     if (tags) {
       data.tags = tags.split(',').map((t: string) => t.trim()).filter(Boolean);
@@ -105,6 +107,17 @@ export function TransactionForm({ onClose, transaction, onSubmit }: TransactionF
               <option key={tag} value={tag} />
             ))}
           </datalist>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            id="hidden"
+            type="checkbox"
+            checked={hidden}
+            onChange={(e) => setHidden(e.target.checked)}
+          />
+          <label htmlFor="hidden" className="text-sm">
+            Hidden
+          </label>
         </div>
         <div className="flex justify-end gap-2">
           <button

--- a/convex/costs.ts
+++ b/convex/costs.ts
@@ -29,6 +29,7 @@ export const monthlyCostBreakdown = query({
     });
 
     oneTime.forEach(o => {
+      if (o.hidden) return;
       if (o.type !== 'expense') return;
       const amt = o.amount / 12;
       add(o.name, amt);

--- a/convex/oneTime.ts
+++ b/convex/oneTime.ts
@@ -20,6 +20,7 @@ export const addOneTimeTransaction = mutation({
     type: v.union(v.literal("income"), v.literal("expense")),
     date: v.number(),
     tags: v.optional(v.array(v.string())),
+    hidden: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
     const userId = await getUserId(ctx);
@@ -36,6 +37,7 @@ export const updateOneTimeTransaction = mutation({
     type: v.optional(v.union(v.literal("income"), v.literal("expense"))),
     date: v.optional(v.number()),
     tags: v.optional(v.array(v.string())),
+    hidden: v.optional(v.boolean()),
   },
   handler: async (ctx, { id, ...updates }) => {
     const userId = await getUserId(ctx);
@@ -92,6 +94,7 @@ export const getYearlyTotals = query({
     let income = 0;
     let expense = 0;
     items.forEach((i) => {
+      if (i.hidden) return;
       if (i.date >= start && i.date < end) {
         if (i.type === "income") income += i.amount;
         else expense += i.amount;
@@ -113,6 +116,7 @@ export const getFutureTotals = query({
     let income = 0;
     let expense = 0;
     items.forEach((i) => {
+      if (i.hidden) return;
       if (i.date >= now) {
         if (i.type === "income") income += i.amount;
         else expense += i.amount;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -160,6 +160,7 @@ export default defineSchema({
     type: v.union(v.literal("income"), v.literal("expense")),
     date: v.number(), // Unix timestamp
     tags: v.optional(v.array(v.string())),
+    hidden: v.optional(v.boolean()),
   }).index("by_user", ["userId"]),
 
   // Store simulation adjustments and results

--- a/lib/costs.ts
+++ b/lib/costs.ts
@@ -14,6 +14,7 @@ export interface OneTimeTransaction {
   amount: number;
   type: 'income' | 'expense';
   name: string;
+  hidden?: boolean;
 }
 
 export interface CostBreakdownItem {
@@ -38,6 +39,7 @@ export function getMonthlyCostBreakdown(
   });
 
   oneTime.forEach((o) => {
+    if (o.hidden) return;
     if (o.type !== 'expense') return;
     const amt = monthlyOneTimeAmount(o.amount);
     add(o.name, amt);


### PR DESCRIPTION
## Summary
- allow toggling hidden flag on one-time transactions
- persist hidden state via update mutation
- exclude hidden one-time items from totals
- support editing hidden status in transaction form

## Testing
- `bun test`
