### PR TITLE
Add manual debt history entry form

### DIFF
--- a/components/debt/debt-details.tsx
+++ b/components/debt/debt-details.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Doc } from "@/convex/_generated/dataModel";
-import { PencilIcon, TrashIcon } from "@heroicons/react/24/outline";
+import { PencilIcon, TrashIcon, PlusIcon } from "@heroicons/react/24/outline";
 import { Modal } from "@/components/modal";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
@@ -12,6 +12,7 @@ import { DebtForm } from '@/components/forms/debt-form';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { formatCurrency } from '@/lib/formatters';
 import DebtHistoryChart from './debt-history-chart';
+import DebtHistoryForm from './debt-history-form';
 
 type Debt = Doc<"debts">;
 
@@ -25,6 +26,7 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
     useQuery(api.debts.getDebt, { id: initialDebt._id }) ?? initialDebt;
   const history = useQuery(api.debts.getDebtHistory, { debtId: initialDebt._id }) ?? [];
   const [showEditForm, setShowEditForm] = useState(false);
+  const [showAddHistoryForm, setShowAddHistoryForm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   
   const updateDebt = useMutation(api.debts.updateDebt);
@@ -163,9 +165,26 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
       </div>
 
       <div className="bg-white/5 rounded-lg p-6 backdrop-blur-sm mb-6">
-        <h2 className="text-xl font-semibold mb-4">Value History</h2>
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-semibold">Value History</h2>
+          <button
+            onClick={() => setShowAddHistoryForm(true)}
+            className="p-2 rounded-full hover:bg-gray-800"
+          >
+            <PlusIcon className="w-5 h-5" />
+          </button>
+        </div>
         <DebtHistoryChart history={history} />
       </div>
+
+      {showAddHistoryForm && (
+        <Modal onClose={() => setShowAddHistoryForm(false)}>
+          <DebtHistoryForm
+            debtId={liveDebt._id}
+            onClose={() => setShowAddHistoryForm(false)}
+          />
+        </Modal>
+      )}
       
       {showEditForm && (
         <Modal onClose={() => setShowEditForm(false)}>

--- a/components/debt/debt-history-form.tsx
+++ b/components/debt/debt-history-form.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Id } from '@/convex/_generated/dataModel';
+
+interface DebtHistoryFormProps {
+  debtId: Id<'debts'>;
+  onClose: () => void;
+}
+
+export default function DebtHistoryForm({ debtId, onClose }: DebtHistoryFormProps) {
+  const [value, setValue] = useState('');
+  const [date, setDate] = useState('');
+
+  const addEntry = useMutation(api.debts.addDebtHistoryEntry);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const timestamp = date ? new Date(date).getTime() : Date.now();
+    await addEntry({ debtId, timestamp, value: Number(value) });
+    onClose();
+  };
+
+  return (
+    <div>
+      <h3 className="text-lg font-medium mb-4">Add History Entry</h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-300" htmlFor="value">
+            Value (USD)
+          </label>
+          <input
+            id="value"
+            type="number"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-gray-100 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            required
+            step="0.01"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-300" htmlFor="date">
+            Date
+          </label>
+          <input
+            id="date"
+            type="date"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-gray-100 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+        <div className="mt-5 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Add Entry
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/convex/debts.ts
+++ b/convex/debts.ts
@@ -232,3 +232,25 @@ export const getDebtHistory = query({
       .collect();
   },
 });
+
+// Manually add a historical value entry for a debt
+export const addDebtHistoryEntry = mutation({
+  args: {
+    debtId: v.id("debts"),
+    timestamp: v.number(),
+    value: v.number(),
+  },
+  handler: async (ctx, { debtId, timestamp, value }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    const userId = identity?.subject;
+
+    const debt = await ctx.db.get(debtId);
+    if (!debt) throw new Error("Debt not found");
+
+    if (debt.userId && debt.userId !== userId) {
+      throw new Error("Not authorized to update this debt");
+    }
+
+    return await ctx.db.insert("debtHistory", { debtId, timestamp, value });
+  },
+});


### PR DESCRIPTION
## Summary
- enable manual debt history entries via new mutation
- add DebtHistoryForm component for entering value & date
- integrate form into debt details UI with a button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6839c104c7c0832a87181b9055053739