### PR TITLE
Add mobile hamburger menu

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,10 +1,27 @@
 'use client';
 import Link from 'next/link';
 import { UserButton } from '@clerk/nextjs';
-import { BeakerIcon, CurrencyDollarIcon, BanknotesIcon } from '@heroicons/react/24/outline';
+import {
+  BeakerIcon,
+  CurrencyDollarIcon,
+  BanknotesIcon,
+  Bars3Icon,
+  XMarkIcon,
+  HomeIcon,
+} from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
+import { useState } from 'react';
 
 export default function Header() {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const navigation = [
+    { href: '/', label: 'Dashboard', icon: HomeIcon },
+    { href: '/simulation', label: 'Simulation', icon: BeakerIcon },
+    { href: '/quotes', label: 'Quotes', icon: CurrencyDollarIcon },
+    { href: '/transactions', label: 'Transactions', icon: BanknotesIcon },
+  ];
+
   return (
     <header className="sticky top-0 z-50 w-full border-b border-gray-700 bg-black/80 backdrop-blur-sm">
       <div className="flex flex-col">
@@ -14,28 +31,52 @@ export default function Header() {
               <Link href="/" className="flex items-center gap-2">
                 <span className="text-xl font-bold">Byldr Finance</span>
               </Link>
-              <nav className="flex items-center gap-6">
-                <Link href="/simulation" className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1">
-                  <BeakerIcon className="w-4 h-4" />
-                  <span>Simulation</span>
-                </Link>
-                <Link href="/quotes" className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1">
-                  <CurrencyDollarIcon className="w-4 h-4" />
-                  <span>Quotes</span>
-                </Link>
-                <Link href="/transactions" className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1">
-                  <BanknotesIcon className="w-4 h-4" />
-                  <span>Transactions</span>
-                </Link>
+              <nav className="hidden lg:flex items-center gap-6">
+                {navigation.map(({ href, label, icon: Icon }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1"
+                  >
+                    <Icon className="w-4 h-4" />
+                    <span>{label}</span>
+                  </Link>
+                ))}
               </nav>
             </div>
             <div className="flex items-center gap-4">
-              <UserButton/>
+              <button
+                className="lg:hidden p-2 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
+                onClick={() => setMobileOpen(!mobileOpen)}
+                aria-label="Toggle navigation"
+                aria-expanded={mobileOpen}
+              >
+                {mobileOpen ? (
+                  <XMarkIcon className="w-6 h-6 text-white" />
+                ) : (
+                  <Bars3Icon className="w-6 h-6 text-white" />
+                )}
+              </button>
+              <UserButton />
             </div>
           </div>
+          {mobileOpen && (
+            <nav className="lg:hidden mt-2 flex flex-col gap-2">
+              {navigation.map(({ href, label, icon: Icon }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className="flex items-center gap-2 rounded px-2 py-1 text-gray-200 hover:text-white hover:bg-gray-800"
+                >
+                  <Icon className="w-4 h-4" />
+                  <span className="text-sm font-medium">{label}</span>
+                </Link>
+              ))}
+            </nav>
+          )}
         </div>
         <QuotesTicker />
       </div>
     </header>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- overhaul header component for mobile friendliness
- add a hamburger button using heroicons
- hide/show links based on screen size
- add dashboard link to navigation and adjust breakpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6839c13ae1c8832aaa4ed767ae3524f6