### PR TITLE
Add editing for debt history entries

### DIFF
--- a/components/debt/debt-details.tsx
+++ b/components/debt/debt-details.tsx
@@ -11,8 +11,9 @@ import Link from "next/link";
 import { DebtForm } from '@/components/forms/debt-form';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { formatCurrency } from '@/lib/formatters';
-import DebtHistoryChart from './debt-history-chart';
+import DebtHistoryChart, { DebtHistoryEntry } from './debt-history-chart';
 import DebtHistoryForm from './debt-history-form';
+import DebtHistoryEditForm from './debt-history-edit-form';
 
 type Debt = Doc<"debts">;
 
@@ -27,6 +28,7 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
   const history = useQuery(api.debts.getDebtHistory, { debtId: initialDebt._id }) ?? [];
   const [showEditForm, setShowEditForm] = useState(false);
   const [showAddHistoryForm, setShowAddHistoryForm] = useState(false);
+  const [editHistoryEntry, setEditHistoryEntry] = useState<DebtHistoryEntry | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   
   const updateDebt = useMutation(api.debts.updateDebt);
@@ -174,7 +176,10 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
             <PlusIcon className="w-5 h-5" />
           </button>
         </div>
-        <DebtHistoryChart history={history} />
+        <DebtHistoryChart
+          history={history}
+          onPointClick={(entry) => setEditHistoryEntry(entry)}
+        />
       </div>
 
       {showAddHistoryForm && (
@@ -192,6 +197,15 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
             debt={liveDebt}
             onClose={() => setShowEditForm(false)}
             onSubmit={handleUpdateDebt}
+          />
+        </Modal>
+      )}
+
+      {editHistoryEntry && (
+        <Modal onClose={() => setEditHistoryEntry(null)}>
+          <DebtHistoryEditForm
+            entry={editHistoryEntry}
+            onClose={() => setEditHistoryEntry(null)}
           />
         </Modal>
       )}

--- a/components/debt/debt-history-chart.tsx
+++ b/components/debt/debt-history-chart.tsx
@@ -9,9 +9,10 @@ export type DebtHistoryEntry = Doc<'debtHistory'>;
 
 interface DebtHistoryChartProps {
   history: DebtHistoryEntry[];
+  onPointClick?: (entry: DebtHistoryEntry) => void;
 }
 
-export default function DebtHistoryChart({ history }: DebtHistoryChartProps) {
+export default function DebtHistoryChart({ history, onPointClick }: DebtHistoryChartProps) {
   if (!history || history.length === 0) {
     return <div className="text-center text-gray-400">No history available</div>;
   }
@@ -19,6 +20,7 @@ export default function DebtHistoryChart({ history }: DebtHistoryChartProps) {
   const data = history
     .sort((a, b) => a.timestamp - b.timestamp)
     .map(h => ({
+      ...h,
       timestamp: h.timestamp,
       value: h.value,
     }));
@@ -56,7 +58,13 @@ export default function DebtHistoryChart({ history }: DebtHistoryChartProps) {
           formatter={(v: number) => formatCurrency(v)}
           labelFormatter={(ts) => new Date(ts as number).toLocaleString()}
         />
-        <Line type="monotone" dataKey="value" stroke="#3b82f6" dot />
+        <Line
+          type="monotone"
+          dataKey="value"
+          stroke="#3b82f6"
+          dot
+          onClick={(data) => onPointClick?.(data.payload as DebtHistoryEntry)}
+        />
       </LineChart>
     </ResponsiveContainer>
   );

--- a/components/debt/debt-history-edit-form.tsx
+++ b/components/debt/debt-history-edit-form.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Doc } from '@/convex/_generated/dataModel';
+
+interface DebtHistoryEditFormProps {
+  entry: Doc<'debtHistory'>;
+  onClose: () => void;
+}
+
+export default function DebtHistoryEditForm({ entry, onClose }: DebtHistoryEditFormProps) {
+  const [value, setValue] = useState(entry.value.toString());
+  const [date, setDate] = useState(new Date(entry.timestamp).toISOString().split('T')[0]);
+
+  const updateEntry = useMutation(api.debts.updateDebtHistoryEntry);
+  const deleteEntry = useMutation(api.debts.deleteDebtHistoryEntry);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await updateEntry({
+      id: entry._id,
+      value: Number(value),
+      timestamp: new Date(date).getTime(),
+    });
+    onClose();
+  };
+
+  const handleDelete = async () => {
+    await deleteEntry({ id: entry._id });
+    onClose();
+  };
+
+  return (
+    <div>
+      <h3 className="text-lg font-medium mb-4">Edit History Entry</h3>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-300" htmlFor="value">
+            Value (USD)
+          </label>
+          <input
+            id="value"
+            type="number"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-gray-100 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            required
+            step="0.01"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-300" htmlFor="date">
+            Date
+          </label>
+          <input
+            id="date"
+            type="date"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-gray-100 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+        <div className="mt-5 flex justify-between gap-3">
+          <button
+            type="button"
+            onClick={handleDelete}
+            className="rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-medium text-red-500 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            Delete
+          </button>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/components/forms/debt-form.tsx
+++ b/components/forms/debt-form.tsx
@@ -20,6 +20,12 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
     debt?.metadata?.interestRate !== undefined ? debt?.metadata.interestRate.toString() : ""
   );
   const [description, setDescription] = useState(debt?.metadata?.description || "");
+  const [originalAmount, setOriginalAmount] = useState(
+    debt?.metadata?.originalAmount !== undefined ? debt.metadata.originalAmount.toString() : value
+  );
+  const [startDate, setStartDate] = useState(
+    debt?.metadata?.startDate ? new Date(debt.metadata.startDate).toISOString().split('T')[0] : ''
+  );
   
   const addDebt = useMutation(api.debts.addDebt);
 
@@ -28,8 +34,8 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
     
     const metadata = {
       description,
-      startDate: debt?.metadata?.startDate || Date.now(),
-      originalAmount: debt?.metadata?.originalAmount || Number(value),
+      startDate: startDate ? new Date(startDate).getTime() : (debt?.metadata?.startDate || Date.now()),
+      originalAmount: originalAmount ? Number(originalAmount) : (debt?.metadata?.originalAmount || Number(value)),
       lastUpdated: Date.now(),
       interestRate: interestRate ? Number(interestRate) : undefined,
       lender: lender || undefined,
@@ -109,6 +115,34 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             required
             min="0"
             step="0.01"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="originalAmount" className="block text-sm font-medium text-gray-300">
+            Original Amount (USD)
+          </label>
+          <input
+            type="number"
+            id="originalAmount"
+            value={originalAmount}
+            onChange={(e) => setOriginalAmount(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-gray-100 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            min="0"
+            step="0.01"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="startDate" className="block text-sm font-medium text-gray-300">
+            Start Date
+          </label>
+          <input
+            type="date"
+            id="startDate"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 text-gray-100 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- allow editing and deleting debt history entries in Convex mutations
- enable clicking on history chart points to edit
- add form for editing/deleting a history entry
- surface original amount and start date fields in debt form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a144302ec832a876e3b8b80ef0e88