### PR TITLE
Add admin quote alias management

### DIFF
--- a/app/admin/quote-aliases/page.tsx
+++ b/app/admin/quote-aliases/page.tsx
@@ -1,0 +1,18 @@
+import { currentUser } from '@clerk/nextjs/server';
+import QuoteAliasManager from '@/components/admin/quote-alias-manager';
+
+export default async function QuoteAliasesPage() {
+  const user = await currentUser();
+  const email = user?.emailAddresses[0]?.emailAddress;
+  if (email !== 'rtcx86@gmail.com') {
+    return <div className="p-8">Not authorized</div>;
+  }
+
+  return (
+    <div className="min-h-screen p-8 pb-20 sm:p-20">
+      <h1 className="text-3xl font-bold mb-6">Quote Aliases</h1>
+      <p className="text-gray-400 mb-8">Map symbols to other quotes or fixed prices.</p>
+      <QuoteAliasManager />
+    </div>
+  );
+}

--- a/app/quotes/page.tsx
+++ b/app/quotes/page.tsx
@@ -2,8 +2,15 @@ import { api } from "@/convex/_generated/api";
 import { preloadQueryWithAuth } from "@/lib/convex";
 import QuotesManager from "@/components/quotes/quotes-manager";
 import { Doc } from "@/convex/_generated/dataModel";
+import { currentUser } from '@clerk/nextjs/server';
 
 export default async function QuotesPage() {
+  const user = await currentUser();
+  const email = user?.emailAddresses[0]?.emailAddress;
+  if (email !== 'rtcx86@gmail.com') {
+    return <div className="p-8">Not authorized</div>;
+  }
+
   // Preload quotes data
   const quotes = await (await preloadQueryWithAuth(api.quotes.listQuotes, {})) as Array<Doc<"quotes">>;
 

--- a/components/admin/quote-alias-manager.tsx
+++ b/components/admin/quote-alias-manager.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { Doc } from '@/convex/_generated/dataModel';
+
+type Alias = Doc<'quoteAliases'>;
+
+export default function QuoteAliasManager() {
+  const aliases = useQuery(api.quoteAliases.listAliases) as Alias[] | undefined;
+  const upsert = useMutation(api.quoteAliases.upsertAlias);
+  const del = useMutation(api.quoteAliases.deleteAlias);
+
+  const [symbol, setSymbol] = useState('');
+  const [quoteSymbol, setQuoteSymbol] = useState('');
+  const [fixedPrice, setFixedPrice] = useState('');
+  const [quoteType, setQuoteType] = useState<'crypto' | 'stock'>('crypto');
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await upsert({
+      symbol: symbol.trim().toUpperCase(),
+      quoteSymbol: quoteSymbol ? quoteSymbol.trim().toUpperCase() : undefined,
+      fixedPrice: fixedPrice ? Number(fixedPrice) : undefined,
+      quoteType
+    });
+    setSymbol('');
+    setQuoteSymbol('');
+    setFixedPrice('');
+  };
+
+  const handleDelete = async (id: string) => {
+    await del({ id: id as any });
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <form onSubmit={handleAdd} className="flex flex-wrap items-end gap-2">
+        <div>
+          <label className="block text-sm">Symbol</label>
+          <input
+            className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
+            value={symbol}
+            onChange={e => setSymbol(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Quote Symbol</label>
+          <input
+            className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
+            value={quoteSymbol}
+            onChange={e => setQuoteSymbol(e.target.value)}
+            placeholder="Use price from"
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Fixed Price</label>
+          <input
+            className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
+            type="number"
+            step="any"
+            value={fixedPrice}
+            onChange={e => setFixedPrice(e.target.value)}
+            placeholder="Override"
+          />
+        </div>
+        <div>
+          <label className="block text-sm">Type</label>
+          <select
+            className="px-2 py-1 rounded bg-gray-800 border border-gray-700"
+            value={quoteType}
+            onChange={e => setQuoteType(e.target.value as 'crypto' | 'stock')}
+          >
+            <option value="crypto">Crypto</option>
+            <option value="stock">Stock</option>
+          </select>
+        </div>
+        <button
+          type="submit"
+          className="bg-blue-600 hover:bg-blue-700 px-3 py-1 rounded"
+        >
+          Add
+        </button>
+      </form>
+
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left border-b border-gray-700">
+            <th className="px-2 py-1">Symbol</th>
+            <th className="px-2 py-1">Quote Symbol</th>
+            <th className="px-2 py-1">Fixed Price</th>
+            <th className="px-2 py-1">Type</th>
+            <th className="px-2 py-1">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {aliases && aliases.map(a => (
+            <tr key={a._id} className="border-b border-gray-800">
+              <td className="px-2 py-1 font-mono">{a.symbol}</td>
+              <td className="px-2 py-1">{a.quoteSymbol || '-'}</td>
+              <td className="px-2 py-1">{a.fixedPrice !== undefined ? a.fixedPrice : '-'}</td>
+              <td className="px-2 py-1">{a.quoteType || '-'}</td>
+              <td className="px-2 py-1">
+                <button
+                  onClick={() => handleDelete(a._id)}
+                  className="text-red-400 hover:text-red-200"
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Link from 'next/link';
-import { UserButton } from '@clerk/nextjs';
+import { UserButton, useUser } from '@clerk/nextjs';
 import {
   BeakerIcon,
   CurrencyDollarIcon,
@@ -14,6 +14,7 @@ import { useState } from 'react';
 
 export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
+  const { user } = useUser();
 
   const navigation = [
     { href: '/', label: 'Dashboard', icon: HomeIcon },
@@ -21,6 +22,10 @@ export default function Header() {
     { href: '/quotes', label: 'Quotes', icon: CurrencyDollarIcon },
     { href: '/transactions', label: 'Transactions', icon: BanknotesIcon },
   ];
+
+  if (user?.emailAddresses[0]?.emailAddress === 'rtcx86@gmail.com') {
+    navigation.push({ href: '/admin/quote-aliases', label: 'Quote Aliases', icon: CurrencyDollarIcon });
+  }
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-gray-700 bg-black/80 backdrop-blur-sm">

--- a/convex/quoteActions.ts
+++ b/convex/quoteActions.ts
@@ -156,6 +156,11 @@ export const updateQuotes = action({
     console.log("Starting quote update...");
     // Get all holdings to determine which quotes we need
     const holdings = await ctx.runQuery(api.holdings.listHoldings, {});
+
+    // Get quote alias mappings
+    const aliases = await ctx.runQuery(api.quoteAliases.listAliases, {});
+    const aliasMap = new Map<string, any>();
+    aliases.forEach((a: any) => aliasMap.set(a.symbol, a));
     
     // Get current quotes
     const currentQuotes = await ctx.runQuery(api.quotes.getQuotes);
@@ -172,28 +177,62 @@ export const updateQuotes = action({
     );
 
     // Get unique symbols from holdings and filter out ignored ones
-    const symbolsToUpdate = [...new Set(holdings.map((h: any) => h.quoteSymbol || h.symbol))]
-      .filter(s => !ignoredSymbols.has(s));
+    const baseSymbols = [...new Set(holdings.map((h: any) => h.quoteSymbol || h.symbol))];
+    const symbolsToProcess = baseSymbols.filter(s => !ignoredSymbols.has(s));
 
-    console.log("Symbols to update:", symbolsToUpdate);
-    
-    // Separate crypto and stock symbols based on holding quote types
-    const cryptoSymbols = symbolsToUpdate.filter(s => holdingQuoteTypes.get(s) === "crypto");
-    const stockSymbols = symbolsToUpdate.filter(s => holdingQuoteTypes.get(s) === "stock");
-    
-    console.log("Crypto symbols:", cryptoSymbols);
-    console.log("Stock symbols:", stockSymbols);
-    
+    console.log("Symbols to process:", symbolsToProcess);
+
+    // Determine which symbols we need to fetch and handle aliases
+    const fetchSymbolSet = new Set<string>();
+    const aliasForSymbol: Record<string, string> = {};
+    const fixedPrices: Record<string, number> = {};
+    const fetchSymbolTypes = new Map<string, string>();
+
+    symbolsToProcess.forEach(symbol => {
+      const alias = aliasMap.get(symbol);
+      if (alias && alias.fixedPrice !== undefined) {
+        fixedPrices[symbol] = alias.fixedPrice;
+      } else {
+        const resolved = alias?.quoteSymbol || symbol;
+        aliasForSymbol[symbol] = resolved;
+        fetchSymbolSet.add(resolved);
+        const t = alias?.quoteType || holdingQuoteTypes.get(symbol);
+        if (t) fetchSymbolTypes.set(resolved, t);
+      }
+    });
+
+    const fetchSymbols = Array.from(fetchSymbolSet);
+    const cryptoSymbols = fetchSymbols.filter(s => fetchSymbolTypes.get(s) === "crypto");
+    const stockSymbols = fetchSymbols.filter(s => fetchSymbolTypes.get(s) === "stock");
+
+    console.log("Fetch crypto symbols:", cryptoSymbols);
+    console.log("Fetch stock symbols:", stockSymbols);
+
     // Get current prices from external APIs
     const cryptoPrices = await getPricesForSymbols(cryptoSymbols);
     const stockPrices = await getStockPrices(stockSymbols);
-    
+
     // Combine prices
-    const prices = { ...cryptoPrices, ...stockPrices };
+    const fetchedPrices = { ...cryptoPrices, ...stockPrices };
+    console.log("Fetched prices:", fetchedPrices);
+
+    // Resolve final prices for each symbol
+    const prices: Record<string, number> = {};
+    symbolsToProcess.forEach(symbol => {
+      if (fixedPrices[symbol] !== undefined) {
+        prices[symbol] = fixedPrices[symbol];
+        return;
+      }
+      const resolved = aliasForSymbol[symbol] || symbol;
+      if (fetchedPrices[resolved] !== undefined) {
+        prices[symbol] = fetchedPrices[resolved];
+      }
+    });
+
     console.log("All prices:", prices);
     
     // Check for missing prices and try to use cached values as fallback
-    const missingSymbols = symbolsToUpdate.filter(s => !prices[s]);
+    const missingSymbols = symbolsToProcess.filter(s => !prices[s]);
     if (missingSymbols.length > 0) {
       console.log(`Missing prices for symbols: ${missingSymbols.join(', ')}. Checking for cached values.`);
       
@@ -246,10 +285,10 @@ export const updateQuotes = action({
     }
     
     console.log(`Updated ${updatedCount} quotes`);
-    return { 
+    return {
       updated: updatedCount,
-      total: symbolsToUpdate.length,
-      skipped: symbolsToUpdate.length - updatedCount
+      total: symbolsToProcess.length,
+      skipped: symbolsToProcess.length - updatedCount
     };
   },
 });
@@ -291,4 +330,13 @@ export const getCryptoQuote = action({
     }
     return prices[symbol] || null;
   }
-}); 
+});
+
+// List all coins from CoinGecko
+export const listCoinGeckoCoins = action({
+  handler: async () => {
+    const res = await fetch('https://api.coingecko.com/api/v3/coins/list');
+    const data = await res.json();
+    return data;
+  }
+});

--- a/convex/quoteAliases.ts
+++ b/convex/quoteAliases.ts
@@ -1,0 +1,55 @@
+import { query, mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const listAliases = query({
+  handler: async (ctx) => {
+    return await ctx.db.query("quoteAliases").collect();
+  }
+});
+
+export const getAlias = query({
+  args: { symbol: v.string() },
+  handler: async (ctx, { symbol }) => {
+    return await ctx.db
+      .query("quoteAliases")
+      .withIndex("by_symbol", q => q.eq("symbol", symbol))
+      .first();
+  }
+});
+
+export const upsertAlias = mutation({
+  args: {
+    symbol: v.string(),
+    quoteSymbol: v.optional(v.string()),
+    fixedPrice: v.optional(v.number()),
+    quoteType: v.optional(v.union(v.literal("crypto"), v.literal("stock")))
+  },
+  handler: async (ctx, { symbol, quoteSymbol, fixedPrice, quoteType }) => {
+    const existing = await ctx.db
+      .query("quoteAliases")
+      .withIndex("by_symbol", q => q.eq("symbol", symbol))
+      .first();
+
+    if (existing) {
+      return await ctx.db.patch(existing._id, {
+        quoteSymbol,
+        fixedPrice,
+        quoteType
+      });
+    } else {
+      return await ctx.db.insert("quoteAliases", {
+        symbol,
+        quoteSymbol,
+        fixedPrice,
+        quoteType
+      });
+    }
+  }
+});
+
+export const deleteAlias = mutation({
+  args: { id: v.id("quoteAliases") },
+  handler: async (ctx, { id }) => {
+    await ctx.db.delete(id);
+  }
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -37,6 +37,14 @@ export default defineSchema({
     ignored: v.optional(v.boolean()), // Whether to ignore this quote in updates and ticker
   }).index("by_symbol", ["symbol"]),
 
+  // Map symbols to alternative quote symbols or fixed prices
+  quoteAliases: defineTable({
+    symbol: v.string(), // Original symbol
+    quoteSymbol: v.optional(v.string()), // Symbol to use for quoting
+    fixedPrice: v.optional(v.number()), // Optional fixed price override
+    quoteType: v.optional(v.union(v.literal("crypto"), v.literal("stock")))
+  }).index("by_symbol", ["symbol"]),
+
   // Store snapshots of quotes at different points in time
   quoteSnapshots: defineTable({
     timestamp: v.number(), // When the snapshot was taken


### PR DESCRIPTION
## Summary
- restrict `/quotes` page to admin email
- show admin-only nav link
- add quote alias manager page for admin
- handle quote alias table in schema and quoting logic
- support listing all coins from CoinGecko

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683a125e8a54832a8ddfd48d5eb81571