### PR TITLE
Add weekly/monthly debt rate

### DIFF
--- a/__tests__/debtChange.test.ts
+++ b/__tests__/debtChange.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from 'bun:test';
+import { calculateChangeRates } from '../lib/debt';
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+test('calculates weekly change using only last week', () => {
+  const history = [
+    { timestamp: 0, value: 100 },
+    { timestamp: WEEK_MS, value: 90 },
+    { timestamp: WEEK_MS * 2, value: 80 }
+  ];
+  const { weeklyChange, monthlyChange } = calculateChangeRates(history);
+  expect(weeklyChange).toBeCloseTo(-10);
+  expect(monthlyChange).toBeNull();
+});
+
+test('calculates monthly change using only last month', () => {
+  const history = [
+    { timestamp: 0, value: 100 },
+    { timestamp: MONTH_MS, value: 80 },
+    { timestamp: MONTH_MS * 2, value: 60 }
+  ];
+  const { weeklyChange, monthlyChange } = calculateChangeRates(history);
+  expect(weeklyChange).toBeNull();
+  expect(monthlyChange).toBeCloseTo(-20);
+});
+
+test('returns null when insufficient recent data', () => {
+  const history = [
+    { timestamp: 0, value: 100 },
+    { timestamp: WEEK_MS / 2, value: 90 }
+  ];
+  const { weeklyChange, monthlyChange } = calculateChangeRates(history);
+  expect(weeklyChange).toBeNull();
+  expect(monthlyChange).toBeNull();
+});

--- a/components/debt/debt-details.tsx
+++ b/components/debt/debt-details.tsx
@@ -15,6 +15,7 @@ import DebtHistoryChart from './debt-history-chart';
 import DebtHistoryList, { DebtHistoryEntry } from './debt-history-list';
 import DebtHistoryForm from './debt-history-form';
 import DebtHistoryEditForm from './debt-history-edit-form';
+import { calculateChangeRates } from '@/lib/debt';
 
 type Debt = Doc<"debts">;
 
@@ -27,6 +28,7 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
   const liveDebt =
     useQuery(api.debts.getDebt, { id: initialDebt._id }) ?? initialDebt;
   const history = useQuery(api.debts.getDebtHistory, { debtId: initialDebt._id }) ?? [];
+  const { weeklyChange, monthlyChange } = calculateChangeRates(history);
   const [showEditForm, setShowEditForm] = useState(false);
   const [showAddHistoryForm, setShowAddHistoryForm] = useState(false);
   const [editHistoryEntry, setEditHistoryEntry] = useState<DebtHistoryEntry | null>(null);
@@ -178,6 +180,26 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
           </button>
         </div>
         <DebtHistoryChart history={history} />
+        {(weeklyChange !== null || monthlyChange !== null) && (
+          <div className="mt-4 text-sm text-gray-300 space-y-1">
+            {weeklyChange !== null && (
+              <p>
+                Avg change per week:{' '}
+                <span className={weeklyChange >= 0 ? 'text-green-400' : 'text-red-400'}>
+                  {formatCurrency(weeklyChange)}
+                </span>
+              </p>
+            )}
+            {monthlyChange !== null && (
+              <p>
+                Avg change per month:{' '}
+                <span className={monthlyChange >= 0 ? 'text-green-400' : 'text-red-400'}>
+                  {formatCurrency(monthlyChange)}
+                </span>
+              </p>
+            )}
+          </div>
+        )}
         <DebtHistoryList history={history} onEdit={(entry) => setEditHistoryEntry(entry)} />
       </div>
 

--- a/lib/debt.ts
+++ b/lib/debt.ts
@@ -1,0 +1,42 @@
+export interface DebtHistoryPoint {
+  timestamp: number;
+  value: number;
+}
+
+export interface DebtChangeRates {
+  weeklyChange: number | null;
+  monthlyChange: number | null;
+}
+
+/**
+ * Calculate average change per week and per month for a debt's value history.
+ * Returns null for a rate if there isn't enough time span between
+ * the first and last data points (7 days for weekly, 30 days for monthly).
+ */
+export function calculateChangeRates(history: DebtHistoryPoint[]): DebtChangeRates {
+  if (!history || history.length < 2) {
+    return { weeklyChange: null, monthlyChange: null };
+  }
+
+  const sorted = [...history].sort((a, b) => a.timestamp - b.timestamp);
+  const last = sorted[sorted.length - 1];
+
+  const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+  const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+
+  function calc(windowMs: number): number | null {
+    const startTime = last.timestamp - windowMs;
+    const points = sorted.filter((p) => p.timestamp >= startTime);
+    if (points.length < 2) return null;
+    const first = points[0];
+    const diffValue = last.value - first.value;
+    const diffMs = last.timestamp - first.timestamp;
+    if (diffMs < windowMs) return null;
+    return diffValue / (diffMs / windowMs);
+  }
+
+  const weeklyChange = calc(WEEK_MS);
+  const monthlyChange = calc(MONTH_MS);
+
+  return { weeklyChange, monthlyChange };
+}


### PR DESCRIPTION
## Summary
- add utility for calculating change rates
- show average weekly/monthly change in debt details
- test change rate calculations

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683a21d37648832a9b982def1bcdf4ea