### PR TITLE
Adjust transactions pie chart drawer

### DIFF
--- a/components/transactions/TransactionsPageClient.tsx
+++ b/components/transactions/TransactionsPageClient.tsx
@@ -15,7 +15,10 @@ import {
   TrashIcon,
   EyeIcon,
   EyeSlashIcon,
+  ChartPieIcon,
+  XMarkIcon,
 } from "@heroicons/react/24/outline";
+import TransactionsPieChart from "./TransactionsPieChart";
 
 interface Props {
   initialRecurring: Doc<"recurringTransactions">[];
@@ -68,6 +71,7 @@ export default function TransactionsPageClient({
   );
   const [editingOneTime, setEditingOneTime] = useState<OneTime | null>(null);
   const [hiddenIds, setHiddenIds] = useState<Set<string>>(new Set());
+  const [showChart, setShowChart] = useState(false);
 
   const allTags = useMemo(
     () => Array.from(new Set([...recurringTags, ...oneTimeTags])),
@@ -145,6 +149,18 @@ export default function TransactionsPageClient({
         (t) => !hiddenIds.has(t._id) && !(t.kind === 'one-time' && t.hidden)
       ),
     [combined, hiddenIds],
+  );
+
+  const pieData = useMemo(
+    () =>
+      visibleItems.map((t) => ({
+        label: t.name,
+        amount:
+          t.kind === 'recurring'
+            ? monthlyAmount(t)
+            : monthlyOneTimeAmount(t.amount),
+      })),
+    [visibleItems],
   );
 
   const monthlyTotals = useMemo(() => {
@@ -603,6 +619,26 @@ export default function TransactionsPageClient({
           />
         </Modal>
       )}
+      {/* Pie chart drawer */}
+      <button
+        onClick={() => setShowChart((prev) => !prev)}
+        className="fixed top-1/4 right-0 z-30 p-2 rounded-l-md bg-blue-600 text-white"
+        aria-label="Toggle chart"
+      >
+        <ChartPieIcon className="w-5 h-5" />
+      </button>
+      <div
+        className={`fixed top-0 right-0 h-full w-96 bg-gray-900 text-gray-100 p-6 transform transition-transform z-20 ${showChart ? 'translate-x-0' : 'translate-x-full'}`}
+      >
+        <button
+          className="absolute top-2 right-2 p-1 text-gray-400 hover:text-white"
+          onClick={() => setShowChart(false)}
+          aria-label="Close chart"
+        >
+          <XMarkIcon className="w-5 h-5" />
+        </button>
+        <TransactionsPieChart data={pieData} />
+      </div>
     </div>
   );
 }

--- a/components/transactions/TransactionsPieChart.tsx
+++ b/components/transactions/TransactionsPieChart.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts';
+import { formatCurrency } from '@/lib/formatters';
+
+interface DataItem {
+  label: string;
+  amount: number;
+}
+
+interface Props {
+  data: DataItem[];
+}
+
+export default function TransactionsPieChart({ data }: Props) {
+  if (!data || data.length === 0) {
+    return <p className="text-gray-400 text-center">No transaction data.</p>;
+  }
+  const COLORS = ['#f87171','#fb923c','#fbbf24','#34d399','#60a5fa','#a78bfa','#f472b6','#facc15','#4ade80','#fca5a5'];
+  const chartData = data.map(d => ({ name: d.label, value: Math.abs(d.amount) }));
+  return (
+    <ResponsiveContainer width="100%" height={480}>
+      <PieChart margin={{ top: 20, right: 40, bottom: 20, left: 40 }}>
+        <Pie
+          data={chartData}
+          dataKey="value"
+          nameKey="name"
+          outerRadius={144}
+        >
+          {chartData.map((_, idx) => (
+            <Cell key={idx} fill={COLORS[idx % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip formatter={(v) => formatCurrency(v as number)} />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- tweak drawer width and toggle position for transactions pie chart
- enlarge the pie chart and add margins to avoid clipping
- remove inline labels from the pie chart

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_683a54820280832a98669ad8ee1c5ed0