### PR TITLE
Add marketing page and SEO

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "About - Byldr Finance",
+  description:
+    "Learn why Byldr Finance is the best tool for forecasting your crypto and personal finances.",
+};
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen p-8 pb-20 sm:p-20">
+      <main className="flex flex-col gap-8 items-center w-full max-w-4xl mx-auto">
+        <h1 className="text-4xl font-bold mb-6 text-center">
+          Forecast your financial life
+        </h1>
+        <p className="text-gray-400 text-center max-w-2xl">
+          Byldr Finance helps you track the real value of your wallets and plan ahead with powerful forecasting tools.
+        </p>
+        <ul className="list-disc pl-6 space-y-4 text-left self-start">
+          <li>Accurately represent unusual tokens like Aave debt tokens.</li>
+          <li>
+            Forecast your portfolio by entering future prices in the simulation tab.
+          </li>
+          <li>Plug in recurring income and expenses on any schedule.</li>
+          <li>
+            See the daily, weekly, monthly and yearly impact of every expense.
+          </li>
+          <li>
+            Tag and filter expenses to quickly separate controllable and fixed costs.
+          </li>
+        </ul>
+        <Link
+          href="/sign-in"
+          className="mt-8 text-blue-400 underline hover:text-blue-300"
+        >
+          Sign in to get started
+        </Link>
+      </main>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,15 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Byldr Finance",
-  description: "Track your net worth and financial assets.",
+  description:
+    "Plan and forecast your finances across crypto and traditional assets. Track unusual tokens, simulate future prices and break down spending.",
+  keywords: [
+    "crypto",
+    "finance",
+    "budgeting",
+    "forecasting",
+    "net worth",
+  ],
 };
 
 export default function RootLayout({

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,6 +8,7 @@ import {
   Bars3Icon,
   XMarkIcon,
   HomeIcon,
+  InformationCircleIcon,
 } from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
 import { useState } from 'react';
@@ -16,6 +17,7 @@ export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const navigation = [
+    { href: '/about', label: 'About', icon: InformationCircleIcon },
     { href: '/', label: 'Dashboard', icon: HomeIcon },
     { href: '/simulation', label: 'Simulation', icon: BeakerIcon },
     { href: '/quotes', label: 'Quotes', icon: CurrencyDollarIcon },

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)'])
+const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/about(.*)'])
 
 export default clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {


### PR DESCRIPTION
## Summary
- add a public marketing page at `/about`
- update middleware to allow public access
- link the new page from the header navigation
- enhance site metadata with SEO keywords

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683a6456b534832aac1ed7bd74a354d5