### PR TITLE
Add marketing homepage and move dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,53 @@
+import { api } from "@/convex/_generated/api";
+import { Doc } from "@/convex/_generated/dataModel";
+import { preloadQueryWithAuth } from "@/lib/convex";
+import { preloadForecastData } from "@/components/forecast/ForecastPreload";
+import { ForecastClient } from "@/components/forecast/ForecastClient";
+import { DailyMetric, UserPreferencesData } from "@/components/forecast/types";
+
+type Asset = Doc<'assets'>;
+type Debt = Doc<'debts'>;
+type Wallet = Doc<'wallets'>;
+
+import AssetsCard from "@/components/cards/assets-card";
+import DebtsCard from "@/components/cards/debts-card";
+
+export default async function Home() {
+  // Preload all data with authentication
+  const [forecastData, assetsPreload, debtsPreload, walletsPreload] = await Promise.all([
+    preloadForecastData(),
+    preloadQueryWithAuth<Asset[]>(api.assets.listAssets, {}),
+    preloadQueryWithAuth<Debt[]>(api.debts.listDebts, {}),
+    preloadQueryWithAuth<Wallet[]>(api.wallets.listWallets, {})
+  ]);
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="flex flex-col gap-8 w-full max-w-6xl mx-auto">
+        <h1 className="text-3xl font-bold">Dashboard</h1>
+
+        <div className="w-full">
+          <ForecastClient 
+            initialMetrics={forecastData.initialMetrics as DailyMetric[]} 
+          initialNetWorth={forecastData.initialNetWorth as {
+            netWorth: number;
+            assets: number;
+            debts: number;
+          } | null}
+          initialPreferences={forecastData.initialPreferences as UserPreferencesData | null}
+          initialRecurring={forecastData.initialRecurring as { monthlyIncome: number; monthlyCost: number } | null}
+          initialOneTimeTotals={forecastData.initialOneTimeTotals as { income: number; expense: number } | null}
+        />
+      </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 w-full">
+          <div className="lg:col-span-2">
+            <AssetsCard assets={assetsPreload || []} wallets={walletsPreload || []} />
+          </div>
+          <div className="lg:col-span-2">
+            <DebtsCard debts={debtsPreload || []} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,15 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Byldr Finance",
-  description: "Track your net worth and financial assets.",
+  description:
+    "Plan and forecast your finances across crypto and traditional assets. Track unusual tokens, simulate future prices and break down spending.",
+  keywords: [
+    "crypto",
+    "finance",
+    "budgeting",
+    "forecasting",
+    "net worth",
+  ],
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,53 +1,42 @@
-import { api } from "@/convex/_generated/api";
-import { Doc } from "@/convex/_generated/dataModel";
-import { preloadQueryWithAuth } from "@/lib/convex";
-import { preloadForecastData } from "@/components/forecast/ForecastPreload";
-import { ForecastClient } from "@/components/forecast/ForecastClient";
-import { DailyMetric, UserPreferencesData } from "@/components/forecast/types";
+import type { Metadata } from "next";
+import Link from "next/link";
 
-type Asset = Doc<'assets'>;
-type Debt = Doc<'debts'>;
-type Wallet = Doc<'wallets'>;
+export const metadata: Metadata = {
+  title: "Byldr Finance - Forecast your financial life",
+  description:
+    "Learn how Byldr Finance helps you plan your crypto and personal finances with accurate tracking and forecasting.",
+};
 
-import AssetsCard from "@/components/cards/assets-card";
-import DebtsCard from "@/components/cards/debts-card";
-
-export default async function Home() {
-  // Preload all data with authentication
-  const [forecastData, assetsPreload, debtsPreload, walletsPreload] = await Promise.all([
-    preloadForecastData(),
-    preloadQueryWithAuth<Asset[]>(api.assets.listAssets, {}),
-    preloadQueryWithAuth<Debt[]>(api.debts.listDebts, {}),
-    preloadQueryWithAuth<Wallet[]>(api.wallets.listWallets, {})
-  ]);
-
+export default function AboutPage() {
   return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="flex flex-col gap-8 w-full max-w-6xl mx-auto">
-        <h1 className="text-3xl font-bold">Dashboard</h1>
-
-        <div className="w-full">
-          <ForecastClient 
-            initialMetrics={forecastData.initialMetrics as DailyMetric[]} 
-          initialNetWorth={forecastData.initialNetWorth as {
-            netWorth: number;
-            assets: number;
-            debts: number;
-          } | null}
-          initialPreferences={forecastData.initialPreferences as UserPreferencesData | null}
-          initialRecurring={forecastData.initialRecurring as { monthlyIncome: number; monthlyCost: number } | null}
-          initialOneTimeTotals={forecastData.initialOneTimeTotals as { income: number; expense: number } | null}
-        />
-      </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 w-full">
-          <div className="lg:col-span-2">
-            <AssetsCard assets={assetsPreload || []} wallets={walletsPreload || []} />
-          </div>
-          <div className="lg:col-span-2">
-            <DebtsCard debts={debtsPreload || []} />
-          </div>
-        </div>
-      </div>
+    <div className="min-h-screen p-8 pb-20 sm:p-20">
+      <main className="flex flex-col gap-8 items-center w-full max-w-4xl mx-auto">
+        <h1 className="text-4xl font-bold mb-6 text-center">
+          Forecast your financial life
+        </h1>
+        <p className="text-gray-400 text-center max-w-2xl">
+          Byldr Finance helps you track the real value of your wallets and plan ahead with powerful forecasting tools.
+        </p>
+        <ul className="list-disc pl-6 space-y-4 text-left self-start">
+          <li>Accurately represent unusual tokens like Aave debt tokens.</li>
+          <li>
+            Forecast your portfolio by entering future prices in the simulation tab.
+          </li>
+          <li>Plug in recurring income and expenses on any schedule.</li>
+          <li>
+            See the daily, weekly, monthly and yearly impact of every expense.
+          </li>
+          <li>
+            Tag and filter expenses to quickly separate controllable and fixed costs.
+          </li>
+        </ul>
+        <Link
+          href="/sign-in"
+          className="mt-8 text-blue-400 underline hover:text-blue-300"
+        >
+          Sign in to get started
+        </Link>
+      </main>
     </div>
   );
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,6 +8,7 @@ import {
   Bars3Icon,
   XMarkIcon,
   HomeIcon,
+  InformationCircleIcon,
 } from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
 import { useState } from 'react';
@@ -16,7 +17,8 @@ export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const navigation = [
-    { href: '/', label: 'Dashboard', icon: HomeIcon },
+    { href: '/', label: 'About', icon: InformationCircleIcon },
+    { href: '/dashboard', label: 'Dashboard', icon: HomeIcon },
     { href: '/simulation', label: 'Simulation', icon: BeakerIcon },
     { href: '/quotes', label: 'Quotes', icon: CurrencyDollarIcon },
     { href: '/transactions', label: 'Transactions', icon: BanknotesIcon },

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(['/sign-in(.*)'])
+const isPublicRoute = createRouteMatcher(['/sign-in(.*)', '/'])
 
 export default clerkMiddleware(async (auth, request) => {
   if (!isPublicRoute(request)) {


### PR DESCRIPTION
## Summary
- make marketing page the root route
- move old dashboard to `/dashboard`
- update navigation links
- tweak metadata and middleware

## Testing
- `npx bun test` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683a6456b534832aac1ed7bd74a354d5