### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import ConvexClientProvider from "./ConvexProvider";
 import { ClerkProvider } from "@clerk/nextjs";
 import Header from "@/components/header";
 import UserTracker from "@/components/user-tracker";
+import { ThemeProvider } from "@/lib/theme-context";
 
 import type { Metadata } from "next";
 
@@ -28,14 +29,16 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="en">
-        <body className="min-h-screen antialiased bg-black text-white">
-          <ConvexClientProvider>
-            <UserTracker />
-            <Header />
-            <main className="flex-1">
-              {children}
-            </main>
-          </ConvexClientProvider>
+        <body className="min-h-screen antialiased bg-white text-black dark:bg-black dark:text-white">
+          <ThemeProvider>
+            <ConvexClientProvider>
+              <UserTracker />
+              <Header />
+              <main className="flex-1">
+                {children}
+              </main>
+            </ConvexClientProvider>
+          </ThemeProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,9 +13,9 @@ export default function AboutPage() {
       <main className="flex flex-col gap-8 items-center w-full max-w-4xl mx-auto">
         <h1 className="font-extrabold mb-6 text-center">
           <span className="block text-blue-600 text-6xl sm:text-8xl">Forecast</span>
-          <span className="block text-white text-5xl sm:text-7xl">Your Financial Life</span>
+          <span className="block text-gray-900 dark:text-white text-5xl sm:text-7xl">Your Financial Life</span>
         </h1>
-        <p className="text-gray-400 text-lg sm:text-2xl text-center max-w-2xl">
+        <p className="text-gray-600 dark:text-gray-400 text-lg sm:text-2xl text-center max-w-2xl">
           Byldr Finance helps you track the real value of your wallets and plan ahead with powerful forecasting tools.
         </p>
         <ul className="list-none pl-0 space-y-4 text-left">
@@ -52,7 +52,7 @@ export default function AboutPage() {
         >
           Start for free
         </Link>
-        <p className="text-gray-400 text-sm mt-2">
+        <p className="text-gray-600 dark:text-gray-400 text-sm mt-2">
           Sign in now—it’s completely free while we’re in beta.
         </p>
       </main>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -12,10 +12,13 @@ import {
 } from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
 import { useState } from 'react';
+import { SunIcon, MoonIcon } from '@heroicons/react/24/outline';
+import { useTheme } from '@/lib/theme-context';
 
 export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
   const { isSignedIn } = useUser();
+  const { theme, toggleTheme } = useTheme();
 
   const navigation = [
     { href: '/', label: 'About', icon: InformationCircleIcon },
@@ -26,7 +29,7 @@ export default function Header() {
   ];
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-gray-700 bg-black/80 backdrop-blur-sm">
+    <header className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-black/80 backdrop-blur-sm">
       <div className="flex flex-col">
         <div className="px-4">
           <div className="container mx-auto max-w-6xl flex h-16 items-center justify-between">
@@ -40,7 +43,7 @@ export default function Header() {
                     <Link
                       key={href}
                       href={href}
-                      className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1"
+                      className="text-sm font-medium text-gray-700 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white flex items-center gap-1"
                     >
                       <Icon className="w-4 h-4" />
                       <span>{label}</span>
@@ -58,16 +61,27 @@ export default function Header() {
                   aria-expanded={mobileOpen}
                 >
                   {mobileOpen ? (
-                    <XMarkIcon className="w-6 h-6 text-white" />
+                    <XMarkIcon className="w-6 h-6 text-gray-800 dark:text-white" />
                   ) : (
-                    <Bars3Icon className="w-6 h-6 text-white" />
+                    <Bars3Icon className="w-6 h-6 text-gray-800 dark:text-white" />
                   )}
                 </button>
               )}
+              <button
+                onClick={toggleTheme}
+                className="p-2 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
+                aria-label="Toggle theme"
+              >
+                {theme === 'dark' ? (
+                  <SunIcon className="w-6 h-6 text-yellow-400" />
+                ) : (
+                  <MoonIcon className="w-6 h-6 text-gray-700" />
+                )}
+              </button>
               {isSignedIn ? (
                 <UserButton afterSignOutUrl="/sign-in" />
               ) : (
-                <Link href="/sign-in" className="text-sm font-medium text-gray-200 hover:text-white">
+                <Link href="/sign-in" className="text-sm font-medium text-gray-700 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white">
                   Sign In
                 </Link>
               )}
@@ -79,7 +93,7 @@ export default function Header() {
                 <Link
                   key={href}
                   href={href}
-                  className="flex items-center gap-2 rounded px-2 py-1 text-gray-200 hover:text-white hover:bg-gray-800"
+                  className="flex items-center gap-2 rounded px-2 py-1 text-gray-700 dark:text-gray-200 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800"
                 >
                   <Icon className="w-4 h-4" />
                   <span className="text-sm font-medium">{label}</span>

--- a/components/modal.tsx
+++ b/components/modal.tsx
@@ -20,7 +20,7 @@ export function Modal({ children, onClose, isOpen = true }: ModalProps) {
           leaveFrom="opacity-100"
           leaveTo="opacity-0"
         >
-          <div className="fixed inset-0 bg-black bg-opacity-50" />
+          <div className="fixed inset-0 bg-black/50" />
         </Transition.Child>
 
         <div className="fixed inset-0 overflow-y-auto">
@@ -34,7 +34,7 @@ export function Modal({ children, onClose, isOpen = true }: ModalProps) {
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-gray-900 text-gray-100 p-6 shadow-xl transition-all">
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 p-6 shadow-xl transition-all">
                 {children}
               </Dialog.Panel>
             </Transition.Child>

--- a/components/quotes-ticker.tsx
+++ b/components/quotes-ticker.tsx
@@ -102,14 +102,14 @@ export default function QuotesTicker() {
   // If no quotes to display, show a message
   if (filteredQuotes.length === 0) {
     return (
-      <div className="w-full bg-black/80 border-b border-gray-800 py-1 text-center text-gray-400">
+      <div className="w-full bg-gray-100 dark:bg-black/80 border-b border-gray-300 dark:border-gray-800 py-1 text-center text-gray-500 dark:text-gray-400">
         No quotes available
       </div>
     );
   }
 
   return (
-    <div className="w-full bg-black/80 border-b border-gray-800 overflow-hidden py-1 relative">
+    <div className="w-full bg-gray-100 dark:bg-black/80 border-b border-gray-300 dark:border-gray-800 overflow-hidden py-1 relative">
       <div className="ticker-container px-4">
         <div className="ticker-text">
           {tickerWords.map((word, index) => (
@@ -119,15 +119,15 @@ export default function QuotesTicker() {
       </div>
       
       {/* Pause/Play button */}
-      <button 
+      <button
         onClick={togglePause}
-        className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-gray-800/70 hover:bg-gray-700/70 rounded-full p-1 z-10"
-        aria-label={isPaused ? "Play ticker" : "Pause ticker"}
+        className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-gray-200/70 dark:bg-gray-800/70 hover:bg-gray-300/70 dark:hover:bg-gray-700/70 rounded-full p-1 z-10"
+        aria-label={isPaused ? 'Play ticker' : 'Pause ticker'}
       >
         {isPaused ? (
-          <PlayIcon className="w-4 h-4 text-white" />
+          <PlayIcon className="w-4 h-4 text-gray-700 dark:text-white" />
         ) : (
-          <PauseIcon className="w-4 h-4 text-white" />
+          <PauseIcon className="w-4 h-4 text-gray-700 dark:text-white" />
         )}
       </button>
     </div>

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -34,7 +34,7 @@ export function Modal({ isOpen, onClose, children }: ModalProps) {
               leaveFrom="opacity-100 scale-100"
               leaveTo="opacity-0 scale-95"
             >
-              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-lg bg-gray-900 p-6 shadow-xl transition-all">
+              <Dialog.Panel className="w-full max-w-md transform overflow-hidden rounded-lg bg-white dark:bg-gray-900 p-6 shadow-xl transition-all">
                 {children}
               </Dialog.Panel>
             </Transition.Child>

--- a/components/wallet/wallet-details.tsx
+++ b/components/wallet/wallet-details.tsx
@@ -192,7 +192,7 @@ export default function WalletDetails({ wallet: initialWallet, holdings: initial
             </div>
             <div className="flex flex-wrap items-baseline">
               <span className="text-gray-400 w-24 text-sm sm:text-base">Address:</span>
-              <span className="ml-2 break-all text-xs sm:text-sm font-mono bg-black/30 p-1 rounded">
+              <span className="ml-2 break-all text-xs sm:text-sm font-mono bg-gray-200/50 dark:bg-black/30 p-1 rounded">
                 {liveWallet.address.length > 20 
                   ? `${liveWallet.address.substring(0, 10)}...${liveWallet.address.substring(liveWallet.address.length - 10)}`
                   : liveWallet.address

--- a/lib/theme-context.tsx
+++ b/lib/theme-context.tsx
@@ -1,0 +1,51 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  // Load initial theme from localStorage or system preference
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'light' || stored === 'dark') {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    } else {
+      setTheme('light');
+    }
+  }, []);
+
+  // Apply theme class to <html> element
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add a theme context with local storage support
- wrap the app with `ThemeProvider`
- update header with theme toggle button and adaptive styles
- tweak components to support both light and dark
- update landing page colors

## Testing
- `bun test`
- `npm run lint` *(fails: prompts to set up ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_683a6fdcf514832a9754439856e33db8