### PR TITLE
Remove about nav item

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -8,7 +8,6 @@ import {
   Bars3Icon,
   XMarkIcon,
   HomeIcon,
-  InformationCircleIcon,
 } from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
 import { useState } from 'react';
@@ -18,7 +17,6 @@ export default function Header() {
   const { isSignedIn } = useUser();
 
   const navigation = [
-    { href: '/', label: 'About', icon: InformationCircleIcon },
     { href: '/dashboard', label: 'Dashboard', icon: HomeIcon },
     { href: '/simulation', label: 'Simulation', icon: BeakerIcon },
     { href: '/quotes', label: 'Quotes', icon: CurrencyDollarIcon },


### PR DESCRIPTION
## Summary
- drop `About` link from the navigation bar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a74b90e10832aa35b2cfdf6cbbaf6