### PR TITLE
Add theme toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,6 +5,16 @@
   --foreground: #171717;
 }
 
+html[data-theme='dark'] {
+  --background: #0a0a0a;
+  --foreground: #ededed;
+}
+
+html[data-theme='light'] {
+  --background: #ffffff;
+  --foreground: #171717;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -13,7 +23,7 @@
 }
 
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not([data-theme]) {
     --background: #0a0a0a;
     --foreground: #ededed;
   }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import ConvexClientProvider from "./ConvexProvider";
 import { ClerkProvider } from "@clerk/nextjs";
 import Header from "@/components/header";
 import UserTracker from "@/components/user-tracker";
+import { ThemeProvider } from "@/components/theme-provider";
 
 import type { Metadata } from "next";
 
@@ -28,14 +29,16 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="en">
-        <body className="min-h-screen antialiased bg-black text-white">
-          <ConvexClientProvider>
-            <UserTracker />
-            <Header />
-            <main className="flex-1">
-              {children}
-            </main>
-          </ConvexClientProvider>
+        <body className="min-h-screen antialiased transition-colors">
+          <ThemeProvider>
+            <ConvexClientProvider>
+              <UserTracker />
+              <Header />
+              <main className="flex-1">
+                {children}
+              </main>
+            </ConvexClientProvider>
+          </ThemeProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -12,6 +12,7 @@ import {
 } from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
 import { useState } from 'react';
+import ThemeToggle from './theme-toggle';
 
 export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -26,7 +27,7 @@ export default function Header() {
   ];
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-gray-700 bg-black/80 backdrop-blur-sm">
+    <header className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-black/80 backdrop-blur-sm">
       <div className="flex flex-col">
         <div className="px-4">
           <div className="container mx-auto max-w-6xl flex h-16 items-center justify-between">
@@ -40,7 +41,7 @@ export default function Header() {
                     <Link
                       key={href}
                       href={href}
-                      className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1"
+                      className="text-sm font-medium text-gray-800 dark:text-gray-200 hover:text-black dark:hover:text-white flex items-center gap-1"
                     >
                       <Icon className="w-4 h-4" />
                       <span>{label}</span>
@@ -58,35 +59,36 @@ export default function Header() {
                   aria-expanded={mobileOpen}
                 >
                   {mobileOpen ? (
-                    <XMarkIcon className="w-6 h-6 text-white" />
+                    <XMarkIcon className="w-6 h-6 text-gray-800 dark:text-white" />
                   ) : (
-                    <Bars3Icon className="w-6 h-6 text-white" />
+                    <Bars3Icon className="w-6 h-6 text-gray-800 dark:text-white" />
                   )}
                 </button>
               )}
+              <ThemeToggle />
               {isSignedIn ? (
                 <UserButton afterSignOutUrl="/sign-in" />
               ) : (
-                <Link href="/sign-in" className="text-sm font-medium text-gray-200 hover:text-white">
+                <Link href="/sign-in" className="text-sm font-medium text-gray-800 dark:text-gray-200 hover:text-black dark:hover:text-white">
                   Sign In
                 </Link>
               )}
             </div>
           </div>
-          {mobileOpen && isSignedIn && (
-            <nav className="lg:hidden mt-2 flex flex-col gap-2">
-              {navigation.map(({ href, label, icon: Icon }) => (
-                <Link
-                  key={href}
-                  href={href}
-                  className="flex items-center gap-2 rounded px-2 py-1 text-gray-200 hover:text-white hover:bg-gray-800"
-                >
-                  <Icon className="w-4 h-4" />
-                  <span className="text-sm font-medium">{label}</span>
-                </Link>
-              ))}
-            </nav>
-          )}
+            {mobileOpen && isSignedIn && (
+              <nav className="lg:hidden mt-2 flex flex-col gap-2">
+                {navigation.map(({ href, label, icon: Icon }) => (
+                  <Link
+                    key={href}
+                    href={href}
+                    className="flex items-center gap-2 rounded px-2 py-1 text-gray-800 dark:text-gray-200 hover:text-black dark:hover:text-white hover:bg-gray-200 dark:hover:bg-gray-800"
+                  >
+                    <Icon className="w-4 h-4" />
+                    <span className="text-sm font-medium">{label}</span>
+                  </Link>
+                ))}
+              </nav>
+            )}
         </div>
         {isSignedIn && <QuotesTicker />}
       </div>

--- a/components/quotes-ticker.tsx
+++ b/components/quotes-ticker.tsx
@@ -102,14 +102,14 @@ export default function QuotesTicker() {
   // If no quotes to display, show a message
   if (filteredQuotes.length === 0) {
     return (
-      <div className="w-full bg-black/80 border-b border-gray-800 py-1 text-center text-gray-400">
+      <div className="w-full bg-white/80 dark:bg-black/80 border-b border-gray-200 dark:border-gray-800 py-1 text-center text-gray-600 dark:text-gray-400">
         No quotes available
       </div>
     );
   }
 
   return (
-    <div className="w-full bg-black/80 border-b border-gray-800 overflow-hidden py-1 relative">
+    <div className="w-full bg-white/80 dark:bg-black/80 border-b border-gray-200 dark:border-gray-800 overflow-hidden py-1 relative text-gray-800 dark:text-gray-100">
       <div className="ticker-container px-4">
         <div className="ticker-text">
           {tickerWords.map((word, index) => (
@@ -119,15 +119,15 @@ export default function QuotesTicker() {
       </div>
       
       {/* Pause/Play button */}
-      <button 
+      <button
         onClick={togglePause}
-        className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-gray-800/70 hover:bg-gray-700/70 rounded-full p-1 z-10"
+        className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-gray-200/70 dark:bg-gray-800/70 hover:bg-gray-300/70 dark:hover:bg-gray-700/70 rounded-full p-1 z-10"
         aria-label={isPaused ? "Play ticker" : "Pause ticker"}
       >
         {isPaused ? (
-          <PlayIcon className="w-4 h-4 text-white" />
+          <PlayIcon className="w-4 h-4 text-gray-800 dark:text-white" />
         ) : (
-          <PauseIcon className="w-4 h-4 text-white" />
+          <PauseIcon className="w-4 h-4 text-gray-800 dark:text-white" />
         )}
       </button>
     </div>

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,45 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'dark',
+  toggle: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    const preferred = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+    const initial = stored ?? preferred;
+    setTheme(initial);
+    document.documentElement.dataset.theme = initial;
+  }, []);
+
+  const toggle = () => {
+    const next = theme === 'dark' ? 'light' : 'dark';
+    setTheme(next);
+    document.documentElement.dataset.theme = next;
+    localStorage.setItem('theme', next);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,21 @@
+'use client'
+import { MoonIcon, SunIcon } from '@heroicons/react/24/outline';
+import { useTheme } from './theme-provider';
+
+export default function ThemeToggle() {
+  const { theme, toggle } = useTheme();
+
+  return (
+    <button
+      onClick={toggle}
+      className="p-2 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
+      aria-label="Toggle theme"
+    >
+      {theme === 'dark' ? (
+        <SunIcon className="w-6 h-6 text-yellow-400" />
+      ) : (
+        <MoonIcon className="w-6 h-6 text-gray-800" />
+      )}
+    </button>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add theme provider and toggle button
- style header and quotes ticker for light/dark themes
- configure Tailwind for class-based dark mode
- hook theme provider into layout

## Testing
- `npm test`
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_683a755fef2c832a81e5b8bd4f1cf968