### PR TITLE
Update forecast chart display

### DIFF
--- a/components/forecast/ForecastChartView.tsx
+++ b/components/forecast/ForecastChartView.tsx
@@ -72,21 +72,21 @@ export function ForecastChartView({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="w-full">
             <h3 className="text-lg font-medium mb-2">Historical Data</h3>
-            <div className="w-full h-[400px]">
+            <div className="w-full h-[450px] md:h-[500px]">
               <NetWorthChart metrics={filteredReal} showUncertainty={false} />
             </div>
           </div>
           
           <div className="w-full">
             <h3 className="text-lg font-medium mb-2">Projected Data</h3>
-            <div className="w-full h-[400px]">
+            <div className="w-full h-[450px] md:h-[500px]">
               <NetWorthChart metrics={filteredProjected} showUncertainty={true} />
             </div>
           </div>
         </div>
       ) : (
-        <div className="w-full h-[400px]">
-          <NetWorthChart 
+        <div className="w-full h-[450px] md:h-[500px]">
+          <NetWorthChart
             metrics={dataView === 'real' ? filteredReal : filteredProjected}
             showUncertainty={dataView === 'projected'}
           />

--- a/components/net-worth-chart.tsx
+++ b/components/net-worth-chart.tsx
@@ -233,12 +233,18 @@ export default function NetWorthChart({ metrics, showUncertainty = true }: NetWo
           }}
         >
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis 
+          <XAxis
             dataKey="timestamp"
             scale="time"
             type="number"
             domain={['auto', 'auto']}
-            tickFormatter={(timestamp) => new Date(timestamp).toLocaleDateString()}
+            tickFormatter={(timestamp) =>
+              new Date(timestamp).toLocaleDateString(undefined, {
+                year: '2-digit',
+                month: 'numeric',
+                day: 'numeric'
+              })
+            }
           />
           <YAxis
             domain={yAxisDomain}


### PR DESCRIPTION
## Summary
- show 2-digit years on the x-axis of forecast charts
- increase forecast chart height on mobile to fit legend
- give charts extra vertical space on desktop

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_683a763c5e2c832a82e806c386bd7125