### PR TITLE
Enable dark theme for Clerk components

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import "@/app/globals.css";
 
 import ConvexClientProvider from "./ConvexProvider";
 import { ClerkProvider } from "@clerk/nextjs";
+import { dark } from "@clerk/themes";
 import Header from "@/components/header";
 import UserTracker from "@/components/user-tracker";
 
@@ -26,7 +27,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <ClerkProvider>
+    <ClerkProvider appearance={{ baseTheme: dark }}>
       <html lang="en">
         <body className="min-h-screen antialiased bg-black text-white">
           <ConvexClientProvider>

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,9 +1,10 @@
 import { SignIn } from '@clerk/nextjs'
+import { dark } from '@clerk/themes'
 
 export default function Page() {
   return (
     <div className="flex justify-center items-center h-screen">
-        <SignIn/>
+        <SignIn appearance={{ baseTheme: dark }}/>
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.12.4",
+    "@clerk/themes": "^2.2.20",
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.2.0",
     "@moralisweb3/common-evm-utils": "^2.27.2",


### PR DESCRIPTION
## Summary
- import `dark` theme from `@clerk/themes`
- apply the theme globally via `ClerkProvider`
- use the same theme on the sign-in page
- add missing dependency for Clerk themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683a7d6c8a24832ab5122219a316b198