### PR TITLE
Switch site to light theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  color-scheme: light;
 }
 
 @theme inline {
@@ -12,12 +13,6 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
 
 body {
   background: var(--background);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,6 @@ import "@/app/globals.css";
 
 import ConvexClientProvider from "./ConvexProvider";
 import { ClerkProvider } from "@clerk/nextjs";
-import { dark } from "@clerk/themes";
 import Header from "@/components/header";
 import UserTracker from "@/components/user-tracker";
 
@@ -27,9 +26,9 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <ClerkProvider appearance={{ baseTheme: dark }}>
+    <ClerkProvider>
       <html lang="en">
-        <body className="min-h-screen antialiased bg-black text-white">
+        <body className="min-h-screen antialiased bg-white text-black">
           <ConvexClientProvider>
             <UserTracker />
             <Header />

--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,10 +1,9 @@
 import { SignIn } from '@clerk/nextjs'
-import { dark } from '@clerk/themes'
 
 export default function Page() {
   return (
     <div className="flex justify-center items-center h-screen">
-        <SignIn appearance={{ baseTheme: dark }}/>
+        <SignIn />
     </div>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,15 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+export default config


### PR DESCRIPTION
## Summary
- remove dark scheme logic from global styles
- update layout to use light colors
- lighten the sign-in page
- disable automatic dark mode generation via Tailwind config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b49ae69a4832ab2d0f083fe785be4