### PR TITLE
Add light theme with tailwind dark mode toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,11 +12,9 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+.dark {
+  --background: #0a0a0a;
+  --foreground: #ededed;
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
   return (
     <ClerkProvider appearance={{ baseTheme: dark }}>
       <html lang="en">
-        <body className="min-h-screen antialiased bg-black text-white">
+        <body className="min-h-screen antialiased bg-white text-black dark:bg-black dark:text-white">
           <ConvexClientProvider>
             <UserTracker />
             <Header />

--- a/app/quotes/page.tsx
+++ b/app/quotes/page.tsx
@@ -12,7 +12,7 @@ export default async function QuotesPage() {
       <main className="flex flex-col gap-8 items-center w-full max-w-6xl mx-auto">
         <div className="w-full">
           <h1 className="text-3xl font-bold mb-6">Quotes Management</h1>
-          <p className="text-gray-400 mb-8">
+          <p className="mb-8">
             Manage which quotes appear in the ticker and are updated automatically.
           </p>
           

--- a/app/simulation/page.tsx
+++ b/app/simulation/page.tsx
@@ -18,7 +18,7 @@ export default async function SimulationPage() {
       <main className="flex flex-col gap-8 items-center w-full max-w-6xl mx-auto">
         <div className="w-full">
           <h1 className="text-3xl font-bold mb-6">Portfolio Simulation</h1>
-          <p className="text-gray-400 mb-8">
+          <p className="mb-8">
             Adjust the price of assets to see how it would affect your portfolio value.
           </p>
           

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -11,6 +11,7 @@ import {
 } from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
 import { useState } from 'react';
+import ThemeToggle from './theme-toggle';
 
 export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -24,7 +25,7 @@ export default function Header() {
   ];
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-gray-700 bg-black/80 backdrop-blur-sm">
+    <header className="sticky top-0 z-50 w-full border-b border-gray-200 bg-white/80 dark:bg-black/80 dark:border-gray-700 backdrop-blur-sm">
       <div className="flex flex-col">
         <div className="px-4">
           <div className="container mx-auto max-w-6xl flex h-16 items-center justify-between">
@@ -38,7 +39,7 @@ export default function Header() {
                     <Link
                       key={href}
                       href={href}
-                      className="text-sm font-medium text-gray-200 hover:text-white flex items-center gap-1"
+                      className="text-sm font-medium flex items-center gap-1"
                     >
                       <Icon className="w-4 h-4" />
                       <span>{label}</span>
@@ -56,19 +57,20 @@ export default function Header() {
                   aria-expanded={mobileOpen}
                 >
                   {mobileOpen ? (
-                    <XMarkIcon className="w-6 h-6 text-white" />
+                    <XMarkIcon className="w-6 h-6" />
                   ) : (
-                    <Bars3Icon className="w-6 h-6 text-white" />
+                    <Bars3Icon className="w-6 h-6" />
                   )}
                 </button>
               )}
               {isSignedIn ? (
                 <UserButton afterSignOutUrl="/sign-in" />
               ) : (
-                <Link href="/sign-in" className="text-sm font-medium text-gray-200 hover:text-white">
+                <Link href="/sign-in" className="text-sm font-medium">
                   Sign In
                 </Link>
               )}
+              <ThemeToggle />
             </div>
           </div>
           {mobileOpen && isSignedIn && (
@@ -77,7 +79,7 @@ export default function Header() {
                 <Link
                   key={href}
                   href={href}
-                  className="flex items-center gap-2 rounded px-2 py-1 text-gray-200 hover:text-white hover:bg-gray-800"
+                  className="flex items-center gap-2 rounded px-2 py-1 hover:bg-gray-100 dark:hover:bg-gray-800"
                 >
                   <Icon className="w-4 h-4" />
                   <span className="text-sm font-medium">{label}</span>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,41 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { SunIcon, MoonIcon } from '@heroicons/react/24/outline'
+
+export default function ThemeToggle() {
+  const [mounted, setMounted] = useState(false)
+  const [dark, setDark] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+    const stored = localStorage.getItem('theme')
+    if (stored === 'dark') {
+      document.documentElement.classList.add('dark')
+      setDark(true)
+    }
+  }, [])
+
+  const toggle = () => {
+    const newDark = !dark
+    setDark(newDark)
+    if (newDark) {
+      document.documentElement.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+    }
+  }
+
+  if (!mounted) return null
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label="Toggle dark mode"
+      className="p-2 rounded focus:outline-none hover:bg-gray-100 dark:hover:bg-gray-800"
+    >
+      {dark ? <SunIcon className="w-5 h-5" /> : <MoonIcon className="w-5 h-5" />}
+    </button>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.12.4",
+        "@clerk/themes": "^2.2.20",
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.2.0",
         "@moralisweb3/common-evm-utils": "^2.27.2",
@@ -457,10 +458,23 @@
         }
       }
     },
+    "node_modules/@clerk/themes": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@clerk/themes/-/themes-2.2.48.tgz",
+      "integrity": "sha512-vylu+2IShOCBr6OBhIFlXL3ULqIZc4L5A/muB0HEum7BHR0bjq6UWHyNZuPKla0W4QGc3azPrTgi19zI4PlZ6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "^4.59.3",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
     "node_modules/@clerk/types": {
-      "version": "4.47.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.47.0.tgz",
-      "integrity": "sha512-xB/gqMq6cq6/47ymKs0WaaxKEFPzlvbSgJTLFIfnPMnFSNwYE4WVgVh6geFx6qWr3z588JDDZkJskBHZlgPmQQ==",
+      "version": "4.59.3",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.59.3.tgz",
+      "integrity": "sha512-xwOO/hfABzbFr3f1RaVXHsDDQ0+jYpm84GiaUDxo+mLsYUgD9f2GmGjKkgWybXzvsBsgZlycSwRXkeDD6utFqg==",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3"

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,14 @@
+import type { Config } from 'tailwindcss'
+
+export default {
+  darkMode: 'class',
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './lib/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config


### PR DESCRIPTION
## Summary
- set Tailwind darkMode to class and add config
- default site styles to light colors and use `.dark` overrides
- implement a `ThemeToggle` component to switch dark mode
- update header and layout to support theme toggle
- remove explicit text color classes so global theme controls colors

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683b47e8b6e0832a8a7a80ecc776d78a