### PR TITLE
Improve debt history chart spacing on mobile

### DIFF
--- a/components/debt/debt-details.tsx
+++ b/components/debt/debt-details.tsx
@@ -80,7 +80,7 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
         <h1 className="text-2xl font-bold">{liveDebt.name}</h1>
       </div>
       
-      <div className="bg-white/5 rounded-lg p-6 backdrop-blur-sm mb-6">
+      <div className="bg-white/5 rounded-lg p-4 sm:p-6 backdrop-blur-sm mb-6">
         <div className="flex justify-between items-start mb-4">
           <div>
             <h2 className="text-xl font-semibold">Debt Details</h2>
@@ -169,7 +169,7 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
         )}
       </div>
 
-      <div className="bg-white/5 rounded-lg p-6 backdrop-blur-sm mb-6">
+      <div className="bg-white/5 rounded-lg p-4 sm:p-6 backdrop-blur-sm mb-6">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-semibold">Value History</h2>
           <button

--- a/components/debt/debt-history-chart.tsx
+++ b/components/debt/debt-history-chart.tsx
@@ -3,7 +3,7 @@
 import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from 'recharts';
 import { Doc } from '@/convex/_generated/dataModel';
 import { formatCompactNumber, formatCurrency } from '@/lib/formatters';
-import { useMemo } from 'react';
+import { useMemo, useEffect, useState } from 'react';
 
 export type DebtHistoryEntry = Doc<'debtHistory'>;
 
@@ -15,6 +15,15 @@ export default function DebtHistoryChart({ history }: DebtHistoryChartProps) {
   if (!history || history.length === 0) {
     return <div className="text-center text-gray-400">No history available</div>;
   }
+
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkScreen = () => setIsMobile(window.innerWidth < 640);
+    checkScreen();
+    window.addEventListener('resize', checkScreen);
+    return () => window.removeEventListener('resize', checkScreen);
+  }, []);
 
   const data = history
     .sort((a, b) => a.timestamp - b.timestamp)
@@ -41,9 +50,13 @@ export default function DebtHistoryChart({ history }: DebtHistoryChartProps) {
     };
   }, [data]);
 
+  const margin = isMobile
+    ? { top: 5, right: 20, left: 10, bottom: 5 }
+    : { top: 5, right: 30, left: 40, bottom: 5 };
+
   return (
     <ResponsiveContainer width="100%" height={300}>
-      <LineChart data={data} margin={{ top: 5, right: 30, left: 40, bottom: 5 }}>
+      <LineChart data={data} margin={margin}>
         <CartesianGrid strokeDasharray="3 3" />
         <XAxis
           dataKey="timestamp"
@@ -52,7 +65,11 @@ export default function DebtHistoryChart({ history }: DebtHistoryChartProps) {
           domain={xDomain}
           tickFormatter={(ts) => new Date(ts as number).toLocaleDateString()}
         />
-        <YAxis domain={yDomain} tickFormatter={(v) => formatCompactNumber(v as number)} />
+        <YAxis
+          domain={yDomain}
+          tickFormatter={(v) => formatCompactNumber(v as number)}
+          width={40}
+        />
         <Tooltip
           formatter={(v: number) => formatCurrency(v)}
           labelFormatter={(ts) => new Date(ts as number).toLocaleString()}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.12.4",
+        "@clerk/themes": "^2.2.20",
         "@headlessui/react": "^2.2.0",
         "@heroicons/react": "^2.2.0",
         "@moralisweb3/common-evm-utils": "^2.27.2",
@@ -457,10 +458,23 @@
         }
       }
     },
+    "node_modules/@clerk/themes": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@clerk/themes/-/themes-2.2.48.tgz",
+      "integrity": "sha512-vylu+2IShOCBr6OBhIFlXL3ULqIZc4L5A/muB0HEum7BHR0bjq6UWHyNZuPKla0W4QGc3azPrTgi19zI4PlZ6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/types": "^4.59.3",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      }
+    },
     "node_modules/@clerk/types": {
-      "version": "4.47.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.47.0.tgz",
-      "integrity": "sha512-xB/gqMq6cq6/47ymKs0WaaxKEFPzlvbSgJTLFIfnPMnFSNwYE4WVgVh6geFx6qWr3z588JDDZkJskBHZlgPmQQ==",
+      "version": "4.59.3",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.59.3.tgz",
+      "integrity": "sha512-xwOO/hfABzbFr3f1RaVXHsDDQ0+jYpm84GiaUDxo+mLsYUgD9f2GmGjKkgWybXzvsBsgZlycSwRXkeDD6utFqg==",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3"


### PR DESCRIPTION
## Summary
- reduce padding for debt details sections on small screens
- shrink mobile left margin for the debt history chart
- set fixed width for the Y axis so the chart uses space better

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683b4d284e0c832a8f0ca2b00bd83f62