### PR TITLE
Fix UI contrast and clean header

### DIFF
--- a/components/forms/asset-form.tsx
+++ b/components/forms/asset-form.tsx
@@ -72,7 +72,7 @@ export function AssetForm({ onClose, asset, onSubmit }: AssetFormProps) {
             id="name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             required
           />
         </div>
@@ -85,7 +85,7 @@ export function AssetForm({ onClose, asset, onSubmit }: AssetFormProps) {
             id="type"
             value={type}
             onChange={(e) => setType(e.target.value as typeof type)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           >
             <option value="real_estate">Real Estate</option>
             <option value="stocks">Stocks</option>
@@ -104,7 +104,7 @@ export function AssetForm({ onClose, asset, onSubmit }: AssetFormProps) {
             id="value"
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             required
             min="0"
             step="0.01"
@@ -120,7 +120,7 @@ export function AssetForm({ onClose, asset, onSubmit }: AssetFormProps) {
             id="purchasePrice"
             value={purchasePrice}
             onChange={(e) => setPurchasePrice(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             min="0"
             step="0.01"
           />
@@ -135,7 +135,7 @@ export function AssetForm({ onClose, asset, onSubmit }: AssetFormProps) {
             id="location"
             value={location}
             onChange={(e) => setLocation(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
         </div>
         
@@ -148,7 +148,7 @@ export function AssetForm({ onClose, asset, onSubmit }: AssetFormProps) {
             id="ticker"
             value={ticker}
             onChange={(e) => setTicker(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
         </div>
         
@@ -160,7 +160,7 @@ export function AssetForm({ onClose, asset, onSubmit }: AssetFormProps) {
             id="description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             rows={3}
           />
         </div>
@@ -169,7 +169,7 @@ export function AssetForm({ onClose, asset, onSubmit }: AssetFormProps) {
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            className="rounded-md border border-gray-600 bg-gray-800 text-white px-4 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
             Cancel
           </button>

--- a/components/forms/debt-form.tsx
+++ b/components/forms/debt-form.tsx
@@ -79,7 +79,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             id="name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             required
           />
         </div>
@@ -92,7 +92,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             id="type"
             value={type}
             onChange={(e) => setType(e.target.value as typeof type)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           >
             <option value="mortgage">Mortgage</option>
             <option value="loan">Loan</option>
@@ -111,7 +111,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             id="value"
             value={value}
             onChange={(e) => setValue(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             required
             min="0"
             step="0.01"
@@ -127,7 +127,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             id="originalAmount"
             value={originalAmount}
             onChange={(e) => setOriginalAmount(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             min="0"
             step="0.01"
           />
@@ -142,7 +142,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             id="startDate"
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
         </div>
 
@@ -155,7 +155,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             id="lender"
             value={lender}
             onChange={(e) => setLender(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           />
         </div>
 
@@ -168,7 +168,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             id="interestRate"
             value={interestRate}
             onChange={(e) => setInterestRate(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             min="0"
             step="0.01"
           />
@@ -182,7 +182,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
             id="description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             rows={3}
           />
         </div>
@@ -191,7 +191,7 @@ export function DebtForm({ onClose, debt, onSubmit }: DebtFormProps) {
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            className="rounded-md border border-gray-600 bg-gray-800 text-white px-4 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
             Cancel
           </button>

--- a/components/forms/wallet-form.tsx
+++ b/components/forms/wallet-form.tsx
@@ -37,7 +37,7 @@ export function WalletForm({ onClose }: WalletFormProps) {
             id="name"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             required
             placeholder={chainType === "virtual" ? "My Coinbase Account" : "My Ethereum Wallet"}
           />
@@ -51,7 +51,7 @@ export function WalletForm({ onClose }: WalletFormProps) {
             id="chainType"
             value={chainType}
             onChange={(e) => setChainType(e.target.value as typeof chainType)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           >
             <option value="ethereum">Ethereum (EVM)</option>
             <option value="solana">Solana</option>
@@ -75,7 +75,7 @@ export function WalletForm({ onClose }: WalletFormProps) {
               id="address"
               value={address}
               onChange={(e) => setAddress(e.target.value)}
-              className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               required
               placeholder={
                 chainType === "ethereum" 
@@ -97,7 +97,7 @@ export function WalletForm({ onClose }: WalletFormProps) {
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            className="rounded-md border border-gray-600 bg-gray-800 text-white px-4 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
             Cancel
           </button>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -24,7 +24,7 @@ export default function Header() {
   ];
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-gray-700 bg-black/80 backdrop-blur-sm">
+    <header className="sticky top-0 z-50 w-full border-b border-gray-700 backdrop-blur-sm">
       <div className="flex flex-col">
         <div className="px-4">
           <div className="container mx-auto max-w-6xl flex h-16 items-center justify-between">

--- a/components/quotes-ticker.tsx
+++ b/components/quotes-ticker.tsx
@@ -88,14 +88,14 @@ export default function QuotesTicker() {
   // If no quotes to display, show a message
   if (filteredQuotes.length === 0) {
     return (
-      <div className="w-full bg-black/80 border-b border-gray-800 py-1 text-center">
+      <div className="w-full border-b border-gray-800 py-1 text-center">
         No quotes available
       </div>
     );
   }
 
   return (
-    <div className="w-full bg-black/80 border-b border-gray-800 overflow-hidden py-1 relative">
+    <div className="w-full border-b border-gray-800 overflow-hidden py-1 relative">
       <div className="ticker-container px-4">
         <div className="ticker-text">
           {tickerWords.map((word, index) => (
@@ -105,9 +105,9 @@ export default function QuotesTicker() {
       </div>
       
       {/* Pause/Play button */}
-      <button 
+      <button
         onClick={togglePause}
-        className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-gray-800/70 hover:bg-gray-700/70 rounded-full p-1 z-10"
+        className="absolute right-2 top-1/2 transform -translate-y-1/2 bg-gray-800/70 hover:bg-gray-700/70 text-white rounded-full p-1 z-10"
         aria-label={isPaused ? "Play ticker" : "Pause ticker"}
       >
         {isPaused ? (

--- a/components/transactions/TransactionsPageClient.tsx
+++ b/components/transactions/TransactionsPageClient.tsx
@@ -625,7 +625,7 @@ export default function TransactionsPageClient({
       {/* Pie chart drawer */}
       <button
         onClick={() => setShowChart((prev) => !prev)}
-        className="fixed top-1/4 right-0 z-30 p-2 rounded-l-md bg-blue-600"
+        className="fixed top-1/4 right-0 z-30 p-2 rounded-l-md bg-blue-600 text-white"
         aria-label="Toggle chart"
       >
         <ChartPieIcon className="w-5 h-5" />
@@ -634,7 +634,7 @@ export default function TransactionsPageClient({
         className={`fixed top-0 right-0 h-full w-96 bg-gray-900 p-6 transform transition-transform z-20 ${showChart ? 'translate-x-0' : 'translate-x-full'}`}
       >
         <button
-          className="absolute top-2 right-2 p-1"
+          className="absolute top-2 right-2 p-1 text-white"
           onClick={() => setShowChart(false)}
           aria-label="Close chart"
         >

--- a/components/wallet/holding-form.tsx
+++ b/components/wallet/holding-form.tsx
@@ -65,7 +65,7 @@ export default function HoldingForm({ walletId, onClose, holding }: HoldingFormP
             id="symbol"
             value={symbol}
             onChange={(e) => setSymbol(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             required
             placeholder="ETH, BTC, USDC, etc."
             disabled={!!holding} // Disable editing symbol for existing holdings
@@ -81,7 +81,7 @@ export default function HoldingForm({ walletId, onClose, holding }: HoldingFormP
             id="quantity"
             value={quantity}
             onChange={(e) => setQuantity(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             required
             step="any"
             min="0"
@@ -97,7 +97,7 @@ export default function HoldingForm({ walletId, onClose, holding }: HoldingFormP
             id="chain"
             value={chain}
             onChange={(e) => setChain(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             disabled={!!holding} // Disable editing chain for existing holdings
           >
             <option value="ethereum">Ethereum</option>
@@ -146,7 +146,7 @@ export default function HoldingForm({ walletId, onClose, holding }: HoldingFormP
             id="quoteSymbol"
             value={quoteSymbol}
             onChange={(e) => setQuoteSymbol(e.target.value)}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
             placeholder="For price lookup, e.g. WETH → ETH"
           />
           <p className="mt-1 text-xs">
@@ -162,7 +162,7 @@ export default function HoldingForm({ walletId, onClose, holding }: HoldingFormP
             id="quoteType"
             value={quoteType}
             onChange={(e) => setQuoteType(e.target.value as "crypto" | "stock")}
-            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-800 text-white px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
           >
             <option value="crypto">Cryptocurrency</option>
             <option value="stock">Stock</option>
@@ -176,7 +176,7 @@ export default function HoldingForm({ walletId, onClose, holding }: HoldingFormP
           <button
             type="button"
             onClick={onClose}
-            className="rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              className="rounded-md border border-gray-600 bg-gray-800 text-white px-4 py-2 text-sm font-medium hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >
             Cancel
           </button>

--- a/components/wallet/wallet-details.tsx
+++ b/components/wallet/wallet-details.tsx
@@ -192,7 +192,7 @@ export default function WalletDetails({ wallet: initialWallet, holdings: initial
             </div>
             <div className="flex flex-wrap items-baseline">
               <span className=" w-24 text-sm sm:text-base">Address:</span>
-              <span className="ml-2 break-all text-xs sm:text-sm font-mono bg-black/30 p-1 rounded">
+              <span className="ml-2 break-all text-xs sm:text-sm font-mono bg-black/30 text-white p-1 rounded">
                 {liveWallet.address.length > 20 
                   ? `${liveWallet.address.substring(0, 10)}...${liveWallet.address.substring(liveWallet.address.length - 10)}`
                   : liveWallet.address


### PR DESCRIPTION
## Summary
- remove header background
- remove marquee background and improve ticker button contrast
- adjust colors on chart drawer buttons
- ensure text is readable on dark inputs
- fix wallet address style

## Testing
- `npm run lint` *(fails: requires interactive setup)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b6f9a6b54832a8ced3469464a763d