### PR TITLE
Improve dashboard styling

### DIFF
--- a/components/cards/assets-card.tsx
+++ b/components/cards/assets-card.tsx
@@ -84,7 +84,7 @@ export default function AssetsCard({ assets: initialAssets, wallets: initialWall
   };
 
   return (
-    <div className="relative bg-white/5 rounded-lg p-6 backdrop-blur-sm">
+    <div className="relative bg-white border border-gray-200 rounded-lg p-6 shadow-sm">
       <h2 className="text-xl font-semibold mb-1">Assets</h2>
       <span className="block text-green-500 font-mono mb-4">
         {`Total: $${formatNumber(total)}`}
@@ -118,7 +118,7 @@ export default function AssetsCard({ assets: initialAssets, wallets: initialWall
                 <Link
                   href={`/wallet/${wallet._id}`}
                   key={wallet._id}
-                  className="flex justify-between items-center p-3 bg-gray-800/50 rounded-lg hover:bg-gray-700/50 transition-colors cursor-pointer"
+                  className="flex justify-between items-center p-3 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
                 >
                   <div className="flex flex-col">
                     <span className="font-medium">{wallet.name}</span>
@@ -150,7 +150,7 @@ export default function AssetsCard({ assets: initialAssets, wallets: initialWall
                 <Link
                   href={`/asset/${asset._id}`}
                   key={asset._id}
-                  className="flex justify-between items-center p-3 bg-gray-800/50 rounded-lg hover:bg-gray-700/50 transition-colors cursor-pointer"
+                  className="flex justify-between items-center p-3 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
                 >
                   <div className="flex items-center">
                     <span className="mr-3 text-xl" aria-hidden="true">{getAssetTypeIcon(asset.type)}</span>

--- a/components/cards/debts-card.tsx
+++ b/components/cards/debts-card.tsx
@@ -48,7 +48,7 @@ export default function DebtsCard({ debts: initialDebts }: DebtsCardProps) {
   };
 
   return (
-    <div className="relative bg-white/5 rounded-lg p-6 backdrop-blur-sm">
+    <div className="relative bg-white border border-gray-200 rounded-lg p-6 shadow-sm">
       <h2 className="text-xl font-semibold mb-1">Debts</h2>
       <span className="block text-red-500 font-mono mb-4">
         {`Total: $${formatNumber(totalDebts)}`}
@@ -68,7 +68,7 @@ export default function DebtsCard({ debts: initialDebts }: DebtsCardProps) {
             <Link 
               href={`/debt/${debt._id}`} 
               key={debt._id}
-              className="flex justify-between items-center p-3 bg-gray-800/50 rounded-lg hover:bg-gray-700/50 transition-colors cursor-pointer"
+              className="flex justify-between items-center p-3 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors cursor-pointer"
             >
               <div className="flex items-center">
                 <span className="mr-3 text-xl" aria-hidden="true">{getDebtTypeIcon(debt.type)}</span>

--- a/components/forecast/ForecastClient.tsx
+++ b/components/forecast/ForecastClient.tsx
@@ -381,7 +381,7 @@ export function ForecastClient({
         prevNetWorth={yesterdayAverage}
       />
       
-      <div className="flex flex-col mb-4 bg-gray-800 p-4 rounded-lg">
+      <div className="flex flex-col mb-4 bg-gray-100 border border-gray-200 p-4 rounded-lg">
         <p className="text-sm">
           Forecasts use your latest simulation data.&nbsp;
           <Link href="/simulation" className="underline text-blue-300">


### PR DESCRIPTION
## Summary
- lighten background of forecast info box so text is legible
- add borders and lighter backgrounds to assets and debts cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683b7233417c832aa438a60fe3d03d87