### PR TITLE
Add debt overview page with history

### DIFF
--- a/app/debt/page.tsx
+++ b/app/debt/page.tsx
@@ -1,0 +1,28 @@
+import { api } from "@/convex/_generated/api";
+import { preloadQueryWithAuth } from "@/lib/convex";
+import { Doc } from "@/convex/_generated/dataModel";
+import DebtOverviewClient from "@/components/debt/debt-overview-client";
+
+export default async function DebtOverviewPage() {
+  const [metrics, debts, wallets] = await Promise.all([
+    preloadQueryWithAuth<Doc<'dailyMetrics'>[]>(api.metrics.getDailyMetrics, {}),
+    preloadQueryWithAuth<Doc<'debts'>[]>(api.debts.listDebts, {}),
+    preloadQueryWithAuth<Doc<'wallets'>[]>(api.wallets.listWallets, {})
+  ]);
+
+  const manualTotal = (debts || []).reduce((sum, d) => sum + d.value, 0);
+  const walletTotal = (wallets || []).reduce((sum, w) => sum + (w.debts || 0), 0);
+
+  const history = (metrics || []).map(m => ({ timestamp: m.date, value: m.debts }));
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Debt Overview</h1>
+      <DebtOverviewClient
+        history={history}
+        manualTotal={manualTotal}
+        walletTotal={walletTotal}
+      />
+    </div>
+  );
+}

--- a/components/debt/debt-overview-client.tsx
+++ b/components/debt/debt-overview-client.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import TotalDebtHistoryChart, { DebtPoint } from './total-debt-history-chart';
+import { formatCurrency } from '@/lib/formatters';
+import { calculateChangeRates } from '@/lib/debt';
+
+interface DebtOverviewClientProps {
+  history: DebtPoint[];
+  manualTotal: number;
+  walletTotal: number;
+}
+
+export default function DebtOverviewClient({ history, manualTotal, walletTotal }: DebtOverviewClientProps) {
+  const combinedTotal = manualTotal + walletTotal;
+  const { weeklyChange, monthlyChange } = calculateChangeRates(history);
+
+  const formatChange = (value: number | null) => {
+    if (value === null) return 'N/A';
+    const sign = value >= 0 ? '+' : '';
+    return `${sign}${formatCurrency(Math.abs(value))}`;
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="bg-white/5 rounded-lg p-4 backdrop-blur-sm">
+          <h3 className="text-sm text-gray-400">Manual Debts</h3>
+          <p className="text-xl font-mono text-red-500">{formatCurrency(manualTotal)}</p>
+        </div>
+        <div className="bg-white/5 rounded-lg p-4 backdrop-blur-sm">
+          <h3 className="text-sm text-gray-400">Wallet Debts</h3>
+          <p className="text-xl font-mono text-red-500">{formatCurrency(walletTotal)}</p>
+        </div>
+        <div className="bg-white/5 rounded-lg p-4 backdrop-blur-sm">
+          <h3 className="text-sm text-gray-400">Total Debt</h3>
+          <p className="text-xl font-mono text-red-500">{formatCurrency(combinedTotal)}</p>
+        </div>
+      </div>
+
+      <div className="bg-white/5 rounded-lg p-4 backdrop-blur-sm">
+        <TotalDebtHistoryChart history={history} />
+        {(weeklyChange !== null || monthlyChange !== null) && (
+          <div className="mt-4 text-sm text-gray-300 space-y-1">
+            {weeklyChange !== null && (
+              <p>
+                Avg change per week:{' '}
+                <span className={weeklyChange >= 0 ? 'text-green-400' : 'text-red-400'}>
+                  {formatChange(weeklyChange)}
+                </span>
+              </p>
+            )}
+            {monthlyChange !== null && (
+              <p>
+                Avg change per month:{' '}
+                <span className={monthlyChange >= 0 ? 'text-green-400' : 'text-red-400'}>
+                  {formatChange(monthlyChange)}
+                </span>
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/debt/total-debt-history-chart.tsx
+++ b/components/debt/total-debt-history-chart.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from 'recharts';
+import { useMemo, useEffect, useState } from 'react';
+import { formatCompactNumber, formatCurrency } from '@/lib/formatters';
+
+export interface DebtPoint {
+  timestamp: number;
+  value: number;
+}
+
+interface TotalDebtHistoryChartProps {
+  history: DebtPoint[];
+}
+
+export default function TotalDebtHistoryChart({ history }: TotalDebtHistoryChartProps) {
+  if (!history || history.length === 0) {
+    return <div className="text-center text-gray-400">No history available</div>;
+  }
+
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkScreen = () => setIsMobile(window.innerWidth < 640);
+    checkScreen();
+    window.addEventListener('resize', checkScreen);
+    return () => window.removeEventListener('resize', checkScreen);
+  }, []);
+
+  const data = history
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .map(h => ({
+      timestamp: h.timestamp,
+      value: h.value,
+    }));
+
+  const { xDomain, yDomain } = useMemo(() => {
+    const timestamps = data.map(d => d.timestamp);
+    const values = data.map(d => d.value);
+    const minT = Math.min(...timestamps);
+    const maxT = Math.max(...timestamps);
+    const minV = Math.min(...values);
+    const maxV = Math.max(...values);
+
+    const xPadding = (maxT - minT) * 0.05 || 86400000; // 1 day default
+    const yPadding = (maxV - minV) * 0.1 || 1;
+
+    return {
+      xDomain: [minT - xPadding, maxT + xPadding],
+      yDomain: [Math.max(0, minV - yPadding), maxV + yPadding]
+    };
+  }, [data]);
+
+  const margin = isMobile
+    ? { top: 5, right: 20, left: 10, bottom: 5 }
+    : { top: 5, right: 30, left: 40, bottom: 5 };
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <LineChart data={data} margin={margin}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis
+          dataKey="timestamp"
+          type="number"
+          scale="time"
+          domain={xDomain}
+          tickFormatter={(ts) => new Date(ts as number).toLocaleDateString()}
+        />
+        <YAxis
+          domain={yDomain}
+          tickFormatter={(v) => formatCompactNumber(v as number)}
+          width={40}
+        />
+        <Tooltip
+          formatter={(v: number) => formatCurrency(v)}
+          labelFormatter={(ts) => new Date(ts as number).toLocaleString()}
+          contentStyle={{
+            backgroundColor: '#1f2937',
+            borderColor: '#374151',
+            color: '#f3f4f6',
+            borderRadius: '0.375rem',
+            boxShadow:
+              '0 4px 6px -1px rgba(0,0,0,0.1), 0 2px 4px -1px rgba(0,0,0,0.06)'
+          }}
+          itemStyle={{ color: '#f3f4f6' }}
+          labelStyle={{ color: '#d1d5db' }}
+        />
+        <Line
+          type="monotone"
+          dataKey="value"
+          stroke="#3b82f6"
+          dot
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- add chart component for combined debt history
- add client to show total manual and wallet debts with change rates
- create debt overview page to gather debt metrics and display chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683dbb76af7c832a951f1fea69957778