### PR TITLE
Improve compact currency precision

### DIFF
--- a/__tests__/formatCompactCurrency.test.ts
+++ b/__tests__/formatCompactCurrency.test.ts
@@ -2,5 +2,5 @@ import { test, expect } from 'bun:test';
 import { formatCompactCurrency } from '../lib/formatters';
 
 test('formats large values with compact notation', () => {
-  expect(formatCompactCurrency(1250000)).toBe('$1.3M');
+  expect(formatCompactCurrency(1250000)).toBe('$1.25M');
 });

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -54,7 +54,9 @@ export function formatCompactCurrency(amount: number, currency: string = 'USD'):
     style: 'currency',
     currency,
     notation: 'compact',
-    compactDisplay: 'short'
+    compactDisplay: 'short',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2
   }).format(amount);
 }
 


### PR DESCRIPTION
## Summary
- allow 2 digits of precision for compact currency display
- adjust tests for new compact currency format

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_68420f24f91c832aaac26dd0dc622872