### PR TITLE
Add tag cloud filtering on cash flow page

### DIFF
--- a/components/cashflow/TagCloud.tsx
+++ b/components/cashflow/TagCloud.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+interface TagCloudProps {
+  tags: string[];
+  selected: Set<string>;
+  onToggle: (tag: string) => void;
+}
+
+export default function TagCloud({ tags, selected, onToggle }: TagCloudProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {tags.map((tag) => (
+        <button
+          key={tag}
+          onClick={() => onToggle(tag)}
+          className={`px-2 py-1 rounded-full text-xs border border-gray-600 ${
+            selected.has(tag)
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-700 text-gray-300'
+          }`}
+        >
+          {tag}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `TagCloud` component to render selectable tag pills
- add include/exclude tag filtering on the cash flow page using tag cloud

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68431a5a2e3c832a9d9d8fe1618fec35