### PR TITLE
Introduce light theme and toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,8 +1,40 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #0a0a0a;
+  --foreground: #ededed;
+  --blue-300: oklch(0.809 0.105 251.813);
+  --blue-400: oklch(0.707 0.165 254.624);
+  --blue-500: oklch(0.623 0.214 259.815);
+  --blue-600: oklch(0.546 0.245 262.881);
+  --blue-700: oklch(0.488 0.243 264.376);
+  --gray-100: oklch(0.967 0.003 264.542);
+  --gray-200: oklch(0.928 0.006 264.531);
+  --gray-300: oklch(0.872 0.01 258.338);
+  --gray-400: oklch(0.707 0.022 261.325);
+  --gray-500: oklch(0.551 0.027 264.364);
+  --gray-600: oklch(0.446 0.03 256.802);
+  --gray-700: oklch(0.373 0.034 259.733);
+  --gray-800: oklch(0.278 0.033 256.848);
+  --gray-900: oklch(0.21 0.034 264.665);
+  --green-200: oklch(0.925 0.084 155.995);
+  --green-300: oklch(0.871 0.15 154.449);
+  --green-400: oklch(0.792 0.209 151.711);
+  --green-500: oklch(0.723 0.219 149.579);
+  --green-600: oklch(0.627 0.194 149.214);
+  --green-700: oklch(0.527 0.154 150.069);
+  --green-900: oklch(0.393 0.095 152.535);
+  --red-200: oklch(0.885 0.062 18.334);
+  --red-400: oklch(0.704 0.191 22.216);
+  --red-500: oklch(0.637 0.237 25.331);
+  --red-600: oklch(0.577 0.245 27.325);
+  --red-700: oklch(0.505 0.213 27.518);
+  --red-900: oklch(0.396 0.141 25.723);
+  --yellow-200: oklch(0.945 0.129 101.54);
+  --yellow-800: oklch(0.476 0.114 61.907);
+  --yellow-900: oklch(0.421 0.095 57.708);
+  --black: #000;
+  --white: #fff;
 }
 
 @theme inline {
@@ -12,11 +44,40 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+
+[data-theme='light'] {
+  --background: #ffffff;
+  --foreground: #171717;
+  --blue-300: #93c5fd;
+  --blue-400: #60a5fa;
+  --blue-500: #3b82f6;
+  --blue-600: #2563eb;
+  --blue-700: #1d4ed8;
+  --gray-100: #f3f4f6;
+  --gray-200: #e5e7eb;
+  --gray-300: #d1d5db;
+  --gray-400: #9ca3af;
+  --gray-500: #6b7280;
+  --gray-600: #4b5563;
+  --gray-700: #374151;
+  --gray-800: #1f2937;
+  --gray-900: #111827;
+  --green-200: #bbf7d0;
+  --green-300: #86efac;
+  --green-400: #4ade80;
+  --green-500: #22c55e;
+  --green-600: #16a34a;
+  --green-700: #15803d;
+  --green-900: #14532d;
+  --red-200: #fecaca;
+  --red-400: #f87171;
+  --red-500: #ef4444;
+  --red-600: #dc2626;
+  --red-700: #b91c1c;
+  --red-900: #7f1d1d;
+  --yellow-200: #fef08a;
+  --yellow-800: #854d0e;
+  --yellow-900: #713f12;
 }
 
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { dark } from "@clerk/themes";
 import Header from "@/components/header";
 import UserTracker from "@/components/user-tracker";
+import { ThemeProvider } from "@/components/theme";
 
 import type { Metadata } from "next";
 
@@ -28,15 +29,17 @@ export default function RootLayout({
 }) {
   return (
     <ClerkProvider appearance={{ baseTheme: dark }}>
-      <html lang="en">
-        <body className="min-h-screen antialiased bg-black text-white">
-          <ConvexClientProvider>
-            <UserTracker />
-            <Header />
-            <main className="flex-1">
-              {children}
-            </main>
-          </ConvexClientProvider>
+      <html lang="en" suppressHydrationWarning>
+        <body className="min-h-screen antialiased bg-background text-foreground">
+          <ThemeProvider>
+            <ConvexClientProvider>
+              <UserTracker />
+              <Header />
+              <main className="flex-1">
+                {children}
+              </main>
+            </ConvexClientProvider>
+          </ThemeProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -11,6 +11,7 @@ import {
 } from '@heroicons/react/24/outline';
 import QuotesTicker from './quotes-ticker';
 import { useState } from 'react';
+import ThemeToggle from './theme-toggle';
 
 export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -62,6 +63,7 @@ export default function Header() {
                   )}
                 </button>
               )}
+              <ThemeToggle />
               {isSignedIn ? (
                 <UserButton afterSignOutUrl="/sign-in" />
               ) : (

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,20 @@
+'use client'
+import { MoonIcon, SunIcon } from '@heroicons/react/24/outline'
+import { useTheme } from './theme'
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+  return (
+    <button
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+      className="p-2 rounded focus:outline-none focus:ring-2 focus:ring-gray-500"
+    >
+      {theme === 'dark' ? (
+        <SunIcon className="w-6 h-6" />
+      ) : (
+        <MoonIcon className="w-6 h-6" />
+      )}
+    </button>
+  )
+}

--- a/components/theme.tsx
+++ b/components/theme.tsx
@@ -1,0 +1,49 @@
+'use client'
+import { createContext, useContext, useEffect, useState } from 'react'
+
+export type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+const THEME_KEY = 'theme'
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('dark')
+
+  useEffect(() => {
+    const stored = (typeof window !== 'undefined' && localStorage.getItem(THEME_KEY)) as Theme | null
+    const initial = stored || 'dark'
+    setTheme(initial)
+    if (typeof document !== 'undefined') {
+      document.documentElement.dataset.theme = initial
+    }
+  }, [])
+
+  const toggleTheme = () => {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(THEME_KEY, next)
+    }
+    if (typeof document !== 'undefined') {
+      document.documentElement.dataset.theme = next
+    }
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,48 @@
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        'blue-300': 'var(--blue-300)',
+        'blue-400': 'var(--blue-400)',
+        'blue-500': 'var(--blue-500)',
+        'blue-600': 'var(--blue-600)',
+        'blue-700': 'var(--blue-700)',
+        'gray-100': 'var(--gray-100)',
+        'gray-200': 'var(--gray-200)',
+        'gray-300': 'var(--gray-300)',
+        'gray-400': 'var(--gray-400)',
+        'gray-500': 'var(--gray-500)',
+        'gray-600': 'var(--gray-600)',
+        'gray-700': 'var(--gray-700)',
+        'gray-800': 'var(--gray-800)',
+        'gray-900': 'var(--gray-900)',
+        'green-200': 'var(--green-200)',
+        'green-300': 'var(--green-300)',
+        'green-400': 'var(--green-400)',
+        'green-500': 'var(--green-500)',
+        'green-600': 'var(--green-600)',
+        'green-700': 'var(--green-700)',
+        'green-900': 'var(--green-900)',
+        'red-200': 'var(--red-200)',
+        'red-400': 'var(--red-400)',
+        'red-500': 'var(--red-500)',
+        'red-600': 'var(--red-600)',
+        'red-700': 'var(--red-700)',
+        'red-900': 'var(--red-900)',
+        'yellow-200': 'var(--yellow-200)',
+        'yellow-800': 'var(--yellow-800)',
+        'yellow-900': 'var(--yellow-900)',
+        'black': 'var(--black)',
+        'white': 'var(--white)',
+        'background': 'var(--background)',
+        'foreground': 'var(--foreground)',
+      }
+    }
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Summary
- add light theme variables and default dark theme in globals
- expose background and foreground colors in Tailwind config
- wrap app with ThemeProvider and add ThemeToggle button in header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68432b7c2248832abbb1db53536871bf