### PR TITLE
Highlight nearest debt history entry

### DIFF
--- a/components/debt/debt-details.tsx
+++ b/components/debt/debt-details.tsx
@@ -200,7 +200,11 @@ export default function DebtDetails({ debt: initialDebt }: DebtDetailsProps) {
             )}
           </div>
         )}
-        <DebtHistoryList history={history} onEdit={(entry) => setEditHistoryEntry(entry)} />
+        <DebtHistoryList
+          history={history}
+          currentValue={liveDebt.value}
+          onEdit={(entry) => setEditHistoryEntry(entry)}
+        />
       </div>
 
       {showAddHistoryForm && (

--- a/components/debt/debt-history-list.tsx
+++ b/components/debt/debt-history-list.tsx
@@ -9,12 +9,19 @@ export type DebtHistoryEntry = Doc<'debtHistory'>;
 
 interface DebtHistoryListProps {
   history: DebtHistoryEntry[];
+  currentValue: number;
   onEdit: (entry: DebtHistoryEntry) => void;
 }
 
-export default function DebtHistoryList({ history, onEdit }: DebtHistoryListProps) {
+export default function DebtHistoryList({ history, currentValue, onEdit }: DebtHistoryListProps) {
   const [open, setOpen] = useState(false);
   const sorted = [...history].sort((a, b) => b.timestamp - a.timestamp);
+
+  // Find the history entry closest to today
+  const now = Date.now();
+  const closest = sorted.reduce((prev, curr) =>
+    Math.abs(curr.timestamp - now) < Math.abs(prev.timestamp - now) ? curr : prev,
+  sorted[0]);
 
   return (
     <div className="mt-4">
@@ -33,9 +40,19 @@ export default function DebtHistoryList({ history, onEdit }: DebtHistoryListProp
       {open && (
         <ul className="mt-2 space-y-2">
           {sorted.map((entry) => (
-            <li key={entry._id} className="flex justify-between items-center rounded-md bg-white/5 px-3 py-2">
-              <span className="text-sm">{new Date(entry.timestamp).toLocaleDateString()}</span>
+            <li
+              key={entry._id}
+              className={`flex justify-between items-center rounded-md px-3 py-2 ${
+                entry._id === closest._id ? 'bg-blue-900/40' : 'bg-white/5'
+              }`}
+            >
+              <span className="text-sm">
+                {new Date(entry.timestamp).toLocaleDateString()}
+              </span>
               <span className="text-sm">{formatCurrency(entry.value)}</span>
+              <span className="text-sm text-gray-400">
+                {formatCurrency(currentValue)}
+              </span>
               <button
                 onClick={() => onEdit(entry)}
                 className="p-1 rounded hover:bg-gray-800"


### PR DESCRIPTION
## Summary
- mark row in debt history closest to today
- show current debt value alongside each history entry

## Testing
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6843521d73f4832ab31e6c4201600d84