### PR TITLE
Improve debt change estimation with regression

### DIFF
--- a/lib/debt.ts
+++ b/lib/debt.ts
@@ -12,7 +12,9 @@ export interface DebtChangeRates {
  * Calculate average change per week and per month for a debt's value history.
  * Returns null for a rate if there isn't enough time span between
  * the first and last data points (7 days for weekly, 30 days for monthly).
- */
+*/
+import { getLinearRegression } from "recharts/lib/util/DataUtils";
+
 export function calculateChangeRates(history: DebtHistoryPoint[]): DebtChangeRates {
   if (!history || history.length < 2) {
     return { weeklyChange: null, monthlyChange: null };
@@ -37,10 +39,12 @@ export function calculateChangeRates(history: DebtHistoryPoint[]): DebtChangeRat
     if (points.length < 2) return null;
     const first = points[0];
     const last = points[points.length - 1];
-    const diffValue = last.value - first.value;
     const diffMs = last.timestamp - first.timestamp;
     if (diffMs === 0) return null;
-    return diffValue / (diffMs / periodMs);
+    const data = points.map((p) => ({ cx: p.timestamp, cy: p.value }));
+    const lr = getLinearRegression(data);
+    if (!lr) return null;
+    return lr.a * periodMs;
   };
 
   const weeklyChange = computeRate(weekHistory, WEEK_MS);


### PR DESCRIPTION
## Summary
- use Recharts `getLinearRegression` for estimating debt change

## Testing
- `bun test`
- `npm install simple-statistics --save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684351bb8a20832abe091ad3f4fd2f70