### PR TITLE
Update asset and debt totals, add simulation toggle

### DIFF
--- a/components/cards/debts-card.tsx
+++ b/components/cards/debts-card.tsx
@@ -51,7 +51,7 @@ export default function DebtsCard({ debts: initialDebts }: DebtsCardProps) {
     <div className="relative bg-white/5 rounded-lg p-6 backdrop-blur-sm">
       <h2 className="text-xl font-semibold mb-1">Debts</h2>
       <span className="block text-red-500 font-mono mb-4">
-        {`Total: $${formatNumber(totalDebts)}`}
+        {`$${formatNumber(totalDebts)}`}
       </span>
       <button
         onClick={() => setShowAddForm(true)}


### PR DESCRIPTION
## Summary
- remove "Total" label on debt and assets cards
- add simulation toggle on the assets card
- show simulated wallet totals when enabled

## Testing
- `bun test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'bun:test')*

------
https://chatgpt.com/codex/tasks/task_e_6843545e35e4832aa9681f59651071d4